### PR TITLE
Rely on upstream client to mark the server as `Status::Ready`

### DIFF
--- a/crates/kcserver/src/heartbeat.rs
+++ b/crates/kcserver/src/heartbeat.rs
@@ -121,23 +121,14 @@ impl HeartbeatMonitor {
                                 .await;
                         }
 
-                        // If this is the first heartbeat, mark the kernel as
-                        // ready if it was starting
+                        // If this is the first heartbeat, log that.
+                        // It is not our job to mark the kernel as `Status::Ready`.
                         if initial {
                             initial = false;
-                            log::trace!(
-                                "[session {}] Received initial heartbeat, marking kernel as ready",
+                            log::info!(
+                                "[session {}] Received initial heartbeat from kernel",
                                 session_id
                             );
-                            let mut state = state.write().await;
-                            if state.status == Status::Starting {
-                                state
-                                    .set_status(
-                                        Status::Ready,
-                                        Some(String::from("initial heartbeat received")),
-                                    )
-                                    .await;
-                            }
                         }
                     }
                     Ok(Err(e)) => {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5708, see https://github.com/posit-dev/positron/issues/5708#issuecomment-2706754958 for the exact analysis of this fix

I'm honestly not sure if this is the right long term fix or not.

---

With this fix, from the Positron side the status changes of a new session look like:

```
starting -> ready (new session) -> busy (kernel_info_request) -> idle (kernel_info_request)
```

From the Kallichore side, the status changes look like:

```
starting -> busy (kernel_info_request) -> idle (kernel_info_request)
```

i.e. because the `-> ready` bit happens on the Positron side and is not backpropagated, Kallichore doesn't know about it. This ends up not being a problem right now because Kallichore doesn't do anything when we move into the `Ready` state, but it _feels_ wrong for the long term?

---

Before this PR, a "normal" startup of a new session (where we didn't get double LSPs) looked like this from the Positron side:

```
starting -> ready (new session) -> ready (initial heartbeat received) -> busy (kernel_info_request) -> idle (kernel_info_request)
```

and this from the Kallichore side:

```
starting -> ready (initial heartbeat received) -> busy (kernel_info_request) -> idle (kernel_info_request)
```

So it was already kind of weird, I think? It's odd that Positron would go through `ready` twice, but Positron was "smart" enough to know that if it was already in `Ready` it should not start up the LSP again.

---

But this is where the race condition could come into play, because it was possible for this ordering to happen on the Positron side during a restart:

```
starting -> ready (initial heartbeat received) -> busy (kernel_info_request) -> ready (restart complete) -> idle (kernel_info_request)
```

i.e. the Kallichore notifications about `ready` could come in faster than Positron was able to mark the kernel as `ready` on its side.

And Positron was _not_ smart enough to ignore the move to `Ready` when we came from `Busy`.

---

Kallichore moved us to `Ready` in exactly 1 place. Positron moves us to ready in many places through `markReady()`. This PR removes the 1 place in Kallichore so we can at least reason about this a bit easier.

In the future the real "correct" fix may be to remove `markReady()` from Positron and to instead rely fully on Kallichore moving us into the `Ready` state. That way Kallichore gets to track that we've moved to `Ready`, and Positron is just a consumer of that info. If you think we should go ahead and do that on the Positron side instead, we can do that too.