### PR TITLE
Fix usage of `restart_session()` in client example

### DIFF
--- a/crates/kallichore_api/examples/client/main.rs
+++ b/crates/kallichore_api/examples/client/main.rs
@@ -170,7 +170,8 @@ fn main() {
         },
         */
         Some("RestartSession") => {
-            let result = rt.block_on(client.restart_session("session_id_example".to_string()));
+            let result =
+                rt.block_on(client.restart_session("session_id_example".to_string(), None));
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,


### PR DESCRIPTION
rust-analyzer marked this file as having an error - missing the `None` in `restart_session()`?