### PR TITLE
Remove 100ms window for detecting websocket handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "kcserver"
-version = "0.1.53"
+version = "0.1.54"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/crates/kcserver/Cargo.toml
+++ b/crates/kcserver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcserver"
-version = "0.1.53"
+version = "0.1.54"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/kcserver/src/client_session.rs
+++ b/crates/kcserver/src/client_session.rs
@@ -304,108 +304,125 @@ impl ClientSession {
             self.client_id
         );
 
-        // We need to peek at the first few bytes to determine if this is a WebSocket
-        // handshake request or if we should treat it as a raw WebSocket connection
+        // Use BufReader to peek at data without consuming it initially
         let mut reader = BufReader::new(stream);
 
-        // Try to read the first line to see if it looks like an HTTP request
-        let mut first_line = String::new();
-        match tokio::time::timeout(
-            tokio::time::Duration::from_millis(100),
-            reader.read_line(&mut first_line),
-        )
-        .await
-        {
-            Ok(Ok(_)) if first_line.starts_with("GET ") => {
-                // This looks like an HTTP WebSocket upgrade request
-                log::debug!(
-                    "[client {}] Detected WebSocket handshake request",
-                    self.client_id
-                );
-
-                // Read the rest of the headers
-                let mut headers = std::collections::HashMap::new();
-                loop {
-                    let mut line = String::new();
-                    if reader.read_line(&mut line).await.is_err() {
-                        break;
-                    }
-                    let line = line.trim();
-                    if line.is_empty() {
-                        break; // End of headers
-                    }
-                    if let Some((key, value)) = line.split_once(':') {
-                        headers.insert(key.trim().to_lowercase(), value.trim().to_string());
-                    }
+        // Peek at the buffered data to check for HTTP request without consuming it
+        let is_http_request = loop {
+            match reader.fill_buf().await {
+                Ok(buf) if buf.len() >= 4 => {
+                    break buf.starts_with(b"GET ");
                 }
-
-                // Generate WebSocket accept key
-                if let Some(websocket_key) = headers.get("sec-websocket-key") {
-                    let accept_key = derive_accept_key(websocket_key.as_bytes());
-
-                    // Send WebSocket handshake response
-                    let response = format!(
-                        "HTTP/1.1 101 Switching Protocols\r\n\
-                         Upgrade: websocket\r\n\
-                         Connection: Upgrade\r\n\
-                         Sec-WebSocket-Accept: {}\r\n\r\n",
-                        accept_key
-                    );
-
-                    let stream = reader.into_inner();
-                    if let Err(e) = stream.writable().await {
-                        log::error!("[client {}] Stream not writable: {}", self.client_id, e);
-                        return;
-                    }
-
-                    if let Err(e) = stream.try_write(response.as_bytes()) {
-                        log::error!(
-                            "[client {}] Failed to send WebSocket handshake response: {}",
-                            self.client_id,
-                            e
-                        );
-                        return;
-                    }
-
-                    log::debug!(
-                        "[client {}] Sent WebSocket handshake response",
-                        self.client_id
-                    );
-
-                    // Now treat it as a raw WebSocket connection (handshake complete)
-                    let ws_stream =
-                        WebSocketStream::from_raw_socket(stream, Role::Server, None).await;
-
-                    log::info!(
-                        "[client {}] Successfully created WebSocket stream from Unix domain socket (with handshake)",
-                        self.client_id
-                    );
-
-                    self.handle_websocket_unix_stream(ws_stream).await;
-                } else {
-                    log::error!(
-                        "[client {}] WebSocket upgrade request missing Sec-WebSocket-Key header",
-                        self.client_id
-                    );
+                Ok(buf) if buf.is_empty() => {
+                    // Connection closed
+                    return;
+                }
+                Ok(_) => {
+                    // Need more data, continue waiting
+                    continue;
+                }
+                Err(e) => {
+                    log::error!("[client {}] Failed to peek at Unix socket data: {}", self.client_id, e);
+                    return;
                 }
             }
-            _ => {
-                // No HTTP request detected, treat as raw WebSocket connection
-                log::debug!(
-                    "[client {}] No WebSocket handshake detected, using raw WebSocket protocol",
-                    self.client_id
+        };
+
+        if is_http_request {
+            // This looks like an HTTP WebSocket upgrade request
+            log::debug!(
+                "[client {}] Detected WebSocket handshake request",
+                self.client_id
+            );
+
+            // Now read the first line (which we know is there)
+            let mut first_line = String::new();
+            if reader.read_line(&mut first_line).await.is_err() {
+                return;
+            }
+
+            // Read the rest of the headers
+            let mut headers = std::collections::HashMap::new();
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).await.is_err() {
+                    break;
+                }
+                let line = line.trim();
+                if line.is_empty() {
+                    break; // End of headers
+                }
+                if let Some((key, value)) = line.split_once(':') {
+                    headers.insert(key.trim().to_lowercase(), value.trim().to_string());
+                }
+            }
+
+            // Generate WebSocket accept key
+            if let Some(websocket_key) = headers.get("sec-websocket-key") {
+                let accept_key = derive_accept_key(websocket_key.as_bytes());
+
+                // Send WebSocket handshake response
+                let response = format!(
+                    "HTTP/1.1 101 Switching Protocols\r\n\
+                     Upgrade: websocket\r\n\
+                     Connection: Upgrade\r\n\
+                     Sec-WebSocket-Accept: {}\r\n\r\n",
+                    accept_key
                 );
 
                 let stream = reader.into_inner();
-                let ws_stream = WebSocketStream::from_raw_socket(stream, Role::Server, None).await;
+                if let Err(e) = stream.writable().await {
+                    log::error!("[client {}] Stream not writable: {}", self.client_id, e);
+                    return;
+                }
+
+                if let Err(e) = stream.try_write(response.as_bytes()) {
+                    log::error!(
+                        "[client {}] Failed to send WebSocket handshake response: {}",
+                        self.client_id,
+                        e
+                    );
+                    return;
+                }
+
+                log::debug!(
+                    "[client {}] Sent WebSocket handshake response",
+                    self.client_id
+                );
+
+                // Now treat it as a raw WebSocket connection (handshake complete)
+                let ws_stream =
+                    WebSocketStream::from_raw_socket(stream, Role::Server, None).await;
 
                 log::info!(
-                    "[client {}] Successfully created WebSocket stream from Unix domain socket (raw)",
+                    "[client {}] Successfully created WebSocket stream from Unix domain socket (with handshake)",
                     self.client_id
                 );
 
                 self.handle_websocket_unix_stream(ws_stream).await;
+            } else {
+                log::error!(
+                    "[client {}] WebSocket upgrade request missing Sec-WebSocket-Key header",
+                    self.client_id
+                );
             }
+        } else {
+            // No HTTP request detected, treat as raw WebSocket connection
+            log::debug!(
+                "[client {}] No WebSocket handshake detected, using raw WebSocket protocol",
+                self.client_id
+            );
+
+            // Convert back to the original stream - any buffered data will be preserved
+            let stream = reader.into_inner();
+            let ws_stream = WebSocketStream::from_raw_socket(stream, Role::Server, None).await;
+
+            log::info!(
+                "[client {}] Successfully created WebSocket stream from Unix domain socket (raw)",
+                self.client_id
+            );
+
+            self.handle_websocket_unix_stream(ws_stream).await;
         }
     }
 
@@ -425,106 +442,123 @@ impl ClientSession {
             session_id
         );
 
-        // We need to peek at the first few bytes to determine if this is a WebSocket
-        // handshake request or if we should treat it as a raw WebSocket connection
+        // Use BufReader to peek at data without consuming it initially
         let mut reader = BufReader::new(stream);
 
-        // Try to read the first line to see if it looks like an HTTP request
-        let mut first_line = String::new();
-        match tokio::time::timeout(
-            tokio::time::Duration::from_millis(100),
-            reader.read_line(&mut first_line),
-        )
-        .await
-        {
-            Ok(Ok(_)) if first_line.starts_with("GET ") => {
-                // This looks like an HTTP WebSocket upgrade request
-                log::debug!(
-                    "[client {}] Detected WebSocket handshake request on named pipe",
-                    self.client_id
+        // Peek at the buffered data to check for HTTP request without consuming it
+        let is_http_request = loop {
+            match reader.fill_buf().await {
+                Ok(buf) if buf.len() >= 4 => {
+                    break buf.starts_with(b"GET ");
+                }
+                Ok(buf) if buf.is_empty() => {
+                    // Connection closed
+                    return;
+                }
+                Ok(_) => {
+                    // Need more data, continue waiting
+                    continue;
+                }
+                Err(e) => {
+                    log::error!("[client {}] Failed to peek at named pipe data: {}", self.client_id, e);
+                    return;
+                }
+            }
+        };
+
+        if is_http_request {
+            // This looks like an HTTP WebSocket upgrade request
+            log::debug!(
+                "[client {}] Detected WebSocket handshake request on named pipe",
+                self.client_id
+            );
+
+            // Now read the first line (which we know is there)
+            let mut first_line = String::new();
+            if reader.read_line(&mut first_line).await.is_err() {
+                return;
+            }
+
+            // Read the rest of the headers
+            let mut headers = std::collections::HashMap::new();
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).await.is_err() {
+                    break;
+                }
+                let line = line.trim();
+                if line.is_empty() {
+                    break; // End of headers
+                }
+                if let Some((key, value)) = line.split_once(':') {
+                    headers.insert(key.trim().to_lowercase(), value.trim().to_string());
+                }
+            }
+
+            // Generate WebSocket accept key
+            if let Some(websocket_key) = headers.get("sec-websocket-key") {
+                let accept_key = derive_accept_key(websocket_key.as_bytes());
+
+                // Send WebSocket handshake response
+                let response = format!(
+                    "HTTP/1.1 101 Switching Protocols\r\n\
+                     Upgrade: websocket\r\n\
+                     Connection: Upgrade\r\n\
+                     Sec-WebSocket-Accept: {}\r\n\r\n",
+                    accept_key
                 );
 
-                // Read the rest of the headers
-                let mut headers = std::collections::HashMap::new();
-                loop {
-                    let mut line = String::new();
-                    if reader.read_line(&mut line).await.is_err() {
-                        break;
-                    }
-                    let line = line.trim();
-                    if line.is_empty() {
-                        break; // End of headers
-                    }
-                    if let Some((key, value)) = line.split_once(':') {
-                        headers.insert(key.trim().to_lowercase(), value.trim().to_string());
-                    }
-                }
-
-                // Generate WebSocket accept key
-                if let Some(websocket_key) = headers.get("sec-websocket-key") {
-                    let accept_key = derive_accept_key(websocket_key.as_bytes());
-
-                    // Send WebSocket handshake response
-                    let response = format!(
-                        "HTTP/1.1 101 Switching Protocols\r\n\
-                         Upgrade: websocket\r\n\
-                         Connection: Upgrade\r\n\
-                         Sec-WebSocket-Accept: {}\r\n\r\n",
-                        accept_key
-                    );
-
-                    let mut stream = reader.into_inner();
-                    use tokio::io::AsyncWriteExt;
-                    if let Err(e) = stream.write_all(response.as_bytes()).await {
-                        log::error!(
-                            "[client {}] Failed to send WebSocket handshake response on named pipe: {}",
-                            self.client_id,
-                            e
-                        );
-                        return;
-                    }
-
-                    if let Err(e) = stream.flush().await {
-                        log::error!(
-                            "[client {}] Failed to flush WebSocket handshake response on named pipe: {}",
-                            self.client_id,
-                            e
-                        );
-                        return;
-                    }
-
-                    log::debug!(
-                        "[client {}] Sent WebSocket handshake response on named pipe",
-                        self.client_id
-                    );
-
-                    // Now treat it as a raw WebSocket connection (handshake complete)
-                    let ws_stream =
-                        WebSocketStream::from_raw_socket(stream, Role::Server, None).await;
-
-                    log::info!(
-                        "[client {}] Successfully created WebSocket stream from named pipe (with handshake)",
-                        self.client_id
-                    );
-
-                    self.handle_websocket_stream(ws_stream).await;
-                } else {
+                let mut stream = reader.into_inner();
+                use tokio::io::AsyncWriteExt;
+                if let Err(e) = stream.write_all(response.as_bytes()).await {
                     log::error!(
-                        "[client {}] WebSocket upgrade request missing Sec-WebSocket-Key header on named pipe",
-                        self.client_id
+                        "[client {}] Failed to send WebSocket handshake response on named pipe: {}",
+                        self.client_id,
+                        e
                     );
+                    return;
                 }
-            }
-            _ => {
-                // No HTTP request detected, fall back to raw JSON protocol
+
+                if let Err(e) = stream.flush().await {
+                    log::error!(
+                        "[client {}] Failed to flush WebSocket handshake response on named pipe: {}",
+                        self.client_id,
+                        e
+                    );
+                    return;
+                }
+
                 log::debug!(
-                    "[client {}] No WebSocket handshake detected on named pipe, using raw JSON protocol",
+                    "[client {}] Sent WebSocket handshake response on named pipe",
                     self.client_id
                 );
 
-                let stream = reader.into_inner();
-                self.handle_named_pipe_stream_raw(stream, session_id).await;
+                // Now treat it as a raw WebSocket connection (handshake complete)
+                let ws_stream =
+                    WebSocketStream::from_raw_socket(stream, Role::Server, None).await;
+
+                log::info!(
+                    "[client {}] Successfully created WebSocket stream from named pipe (with handshake)",
+                    self.client_id
+                );
+
+                self.handle_websocket_stream(ws_stream).await;
+            } else {
+                log::error!(
+                    "[client {}] WebSocket upgrade request missing Sec-WebSocket-Key header on named pipe",
+                    self.client_id
+                );
             }
+        } else {
+            // No HTTP request detected, fall back to raw JSON protocol
+            log::debug!(
+                "[client {}] No WebSocket handshake detected on named pipe, using raw JSON protocol",
+                self.client_id
+            );
+
+            // Convert back to the original stream - any buffered data will be preserved
+            let stream = reader.into_inner();
+            self.handle_named_pipe_stream_raw(stream, session_id).await;
         }
     }
 


### PR DESCRIPTION
Currently, we wait up to 100ms to see if the session websocket will receive a handshake request before switching to a raw websocket connection. This means that if the handshake request arrives after this window, it will be treated as raw websocket data, generating errors.

This change removes the 100ms window and just checks the first bytes that arrive (whatever they are). 

Addresses https://github.com/posit-dev/positron/issues/9680