### PR TITLE
Don't log auth token if written to file

### DIFF
--- a/crates/kcserver/src/main.rs
+++ b/crates/kcserver/src/main.rs
@@ -355,8 +355,11 @@ async fn main() {
                 hex_string.push_str(&format!("{:02x}", byte));
             }
 
-            // Log the generated token for debugging purposes
-            log::info!("Generated random auth token: {}", hex_string);
+            // If the token is generated and no connection file is specified,
+            // log it to the console as there's otherwise no way to retrieve it
+            if args.connection_file.is_none() {
+                log::info!("Generated random auth token: {}", hex_string);
+            }
 
             Some(hex_string)
         }


### PR DESCRIPTION
For security, don't log the auth token if it's written to a connection file.