### PR TITLE
Add NOTICE file generated from license-mole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ target/
 
 # Exuberant Ctags
 tags
+
+# Ignore License Mole caches
+.mole.license_cache.json
+.mole.rust_cache/
+.mole.web_cache/
+
+# macOS
+.DS_Store

--- a/.mole.scan_cache.json
+++ b/.mole.scan_cache.json
@@ -1,0 +1,7226 @@
+{
+ "Rust": {
+  "kallichore": {
+   "!locks": [
+    "e557e9448dd0db989d8929a929b70d0e691d6685f34767ecdbf92c8d514a3f64"
+   ],
+   "rust::addr2line": {
+    "name": "addr2line",
+    "path": ".mole.rust_cache/kcshared/addr2line-0.22.0",
+    "version": "0.22.0",
+    "attribution": [
+     "Copyright 2016-2018 The gimli Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/addr2line-0.22.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/addr2line-0.22.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016-2018 The gimli Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/gimli-rs/addr2line",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "addr2line"
+    ]
+   },
+   "rust::adler": {
+    "name": "adler",
+    "path": ".mole.rust_cache/kcshared/adler-1.0.2",
+    "version": "1.0.2",
+    "author": "Jonas Schievink <jonasschievink@gmail.com>",
+    "attribution": [
+     "Copyright (C) Jonas Schievink <jonasschievink@gmail.com>"
+    ],
+    "licenses": [
+     "0BSD",
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/adler-1.0.2/LICENSE-APACHE": {
+      "checksum": "24d69d3c451bf71955340f731ec34a12aff655b7ca0bb5dbe4afc022ec146b5e",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/adler-1.0.2/LICENSE-0BSD": {
+      "checksum": "5ceaba797e5ea602359fc2e88654abc8e7719fb473ebefc51c51aee050d3ab36",
+      "attribution": [
+       "Copyright (C) Jonas Schievink <jonasschievink@gmail.com>"
+      ]
+     },
+     ".mole.rust_cache/kcshared/adler-1.0.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/jonas-schievink/adler",
+    "ltype": "0BSD OR MIT OR Apache-2.0",
+    "children": [
+     "adler"
+    ]
+   },
+   "rust::aho-corasick": {
+    "name": "aho-corasick",
+    "path": ".mole.rust_cache/kcshared/aho-corasick-1.1.3",
+    "version": "1.1.3",
+    "author": "Andrew Gallant <jamslam@gmail.com>",
+    "attribution": [
+     "Copyright 2015 Andrew Gallant"
+    ],
+    "licenses": [
+     "MIT",
+     "Unlicense"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/aho-corasick-1.1.3/COPYING": {
+      "checksum": "18cb1e425a6d45a4e98b6fc3b4d85f85d333862fe906555b2168e8234fefe111",
+      "guess": "MIT",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/aho-corasick-1.1.3/UNLICENSE": {
+      "checksum": "daa475343600cbb7ef14411d59b1eea77fb8f66c48dcc8cb6cceb9cdbe0c07a9",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/aho-corasick-1.1.3/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Andrew Gallant"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/BurntSushi/aho-corasick",
+    "ltype": "Unlicense OR MIT",
+    "children": [
+     "aho-corasick"
+    ]
+   },
+   "rust::android-tzdata": {
+    "name": "android-tzdata",
+    "path": ".mole.rust_cache/kcshared/android-tzdata-0.1.1",
+    "version": "0.1.1",
+    "author": "RumovZ",
+    "attribution": [
+     "Copyright [year] [fullname]"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/android-tzdata-0.1.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/android-tzdata-0.1.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright [year] [fullname]"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/RumovZ/android-tzdata",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "android-tzdata"
+    ]
+   },
+   "rust::android_system_properties": {
+    "name": "android_system_properties",
+    "path": ".mole.rust_cache/kcshared/android_system_properties-0.1.5",
+    "version": "0.1.5",
+    "author": "Nicolas Silva <nical@fastmail.com>",
+    "attribution": [
+     "Copyright 2013 Nicolas Silva",
+     "Copyright 2016 Nicolas Silva"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/android_system_properties-0.1.5/LICENSE-APACHE": {
+      "checksum": "5e2bb1e6b78861a8b13150f493003aedab4168a1f338b8d4cea4763255a99ece",
+      "attribution": [
+       "Copyright 2016 Nicolas Silva"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcshared/android_system_properties-0.1.5/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2013 Nicolas Silva"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/nical/android_system_properties",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "android_system_properties"
+    ]
+   },
+   "rust::ansi_term": {
+    "name": "ansi_term",
+    "path": ".mole.rust_cache/kcshared/ansi_term-0.12.1",
+    "version": "0.12.1",
+    "author": "ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>",
+    "attribution": [
+     "Copyright 2014 Benjamin Sago"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/ansi_term-0.12.1/LICENCE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Benjamin Sago"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/ogham/rust-ansi-term",
+    "ltype": "MIT",
+    "children": [
+     "ansi_term"
+    ]
+   },
+   "rust::anstream": {
+    "name": "anstream",
+    "path": ".mole.rust_cache/kcshared/anstream-0.6.15",
+    "version": "0.6.15",
+    "attribution": [
+     "Copyright Individual contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/anstream-0.6.15/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/anstream-0.6.15/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright Individual contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-cli/anstyle",
+    "ltype": "MIT OR Apache-2.0",
+    "rename": "anstream",
+    "children": [
+     "anstream"
+    ]
+   },
+   "rust::anstyle": {
+    "name": "anstyle",
+    "path": ".mole.rust_cache/kcshared/anstyle-1.0.8",
+    "version": "1.0.8",
+    "attribution": [
+     "Copyright 2022 The rust-cli Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/anstyle-1.0.8/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/anstyle-1.0.8/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2022 The rust-cli Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-cli/anstyle",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "anstyle"
+    ]
+   },
+   "rust::anstyle-parse": {
+    "name": "anstyle-parse",
+    "path": ".mole.rust_cache/kcshared/anstyle-parse-0.2.5",
+    "version": "0.2.5",
+    "attribution": [
+     "Copyright 2016 Joe Wilm and individual contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/anstyle-parse-0.2.5/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/anstyle-parse-0.2.5/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Joe Wilm and individual contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-cli/anstyle",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "anstyle-parse"
+    ]
+   },
+   "rust::anstyle-query": {
+    "name": "anstyle-query",
+    "path": ".mole.rust_cache/kcshared/anstyle-query-1.1.1",
+    "version": "1.1.1",
+    "attribution": [
+     "Copyright Individual contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/anstyle-query-1.1.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/anstyle-query-1.1.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright Individual contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-cli/anstyle",
+    "ltype": "MIT OR Apache-2.0",
+    "rename": "anstyle-query",
+    "children": [
+     "anstyle-query"
+    ]
+   },
+   "rust::anstyle-wincon": {
+    "name": "anstyle-wincon",
+    "path": ".mole.rust_cache/kcshared/anstyle-wincon-3.0.4",
+    "version": "3.0.4",
+    "attribution": [
+     "Copyright 2015 Josh Triplett, 2022 The rust-cli Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/anstyle-wincon-3.0.4/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/anstyle-wincon-3.0.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Josh Triplett, 2022 The rust-cli Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-cli/anstyle",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "anstyle-wincon"
+    ]
+   },
+   "rust::anyhow": {
+    "name": "anyhow",
+    "path": ".mole.rust_cache/kcshared/anyhow-1.0.86",
+    "version": "1.0.86",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/anyhow-1.0.86/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/anyhow-1.0.86/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/anyhow",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "anyhow"
+    ]
+   },
+   "rust::async-channel": {
+    "name": "async-channel",
+    "path": ".mole.rust_cache/kcshared/async-channel-2.3.1",
+    "version": "2.3.1",
+    "author": "Stjepan Glavina <stjepang@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/async-channel-2.3.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/async-channel-2.3.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/smol-rs/async-channel",
+    "ltype": "Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "async-channel"
+    ]
+   },
+   "rust::async-stream": {
+    "name": "async-stream",
+    "path": ".mole.rust_cache/kcshared/async-stream-0.3.6",
+    "version": "0.3.6",
+    "author": "Carl Lerche <me@carllerche.com>",
+    "attribution": [
+     "Copyright 2018 David Tolnay",
+     "Copyright 2019 Carl Lerche"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/async-stream-0.3.6/LICENSE": {
+      "checksum": "94fa952acfc8af0b610cf8e85b3d3be563244f3abd0a638484e3fa93dc720ea8",
+      "attribution": [
+       "Copyright 2018 David Tolnay",
+       "Copyright 2019 Carl Lerche"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tokio-rs/async-stream",
+    "ltype": "MIT",
+    "children": [
+     "async-stream",
+     "async-stream-impl"
+    ]
+   },
+   "rust::async-trait": {
+    "name": "async-trait",
+    "path": ".mole.rust_cache/kcshared/async-trait-0.1.80",
+    "version": "0.1.80",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/async-trait-0.1.80/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/async-trait-0.1.80/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/async-trait",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "async-trait"
+    ]
+   },
+   "rust::asynchronous-codec": {
+    "name": "asynchronous-codec",
+    "path": ".mole.rust_cache/kcshared/asynchronous-codec-0.7.0",
+    "version": "0.7.0",
+    "author": "Max Inden <mail@max-inden.de>",
+    "attribution": [
+     "Copyright 2019 - 2020 Matt Hunzinger",
+     "Copyright 2021 Max Inden"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/asynchronous-codec-0.7.0/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 - 2020 Matt Hunzinger",
+       "Copyright 2021 Max Inden"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/mxinden/asynchronous-codec",
+    "ltype": "MIT",
+    "children": [
+     "asynchronous-codec"
+    ]
+   },
+   "rust::atty": {
+    "name": "atty",
+    "path": ".mole.rust_cache/kcshared/atty-0.2.14",
+    "version": "0.2.14",
+    "author": "softprops <d.tangren@gmail.com>",
+    "attribution": [
+     "Copyright 2015-2019 Doug Tangren"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/atty-0.2.14/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015-2019 Doug Tangren"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/softprops/atty",
+    "ltype": "MIT",
+    "children": [
+     "atty"
+    ]
+   },
+   "rust::autocfg": {
+    "name": "autocfg",
+    "path": ".mole.rust_cache/kcshared/autocfg-1.3.0",
+    "version": "1.3.0",
+    "author": "Josh Stone <cuviper@gmail.com>",
+    "attribution": [
+     "Copyright 2018 Josh Stone"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/autocfg-1.3.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/autocfg-1.3.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 Josh Stone"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/cuviper/autocfg",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "autocfg"
+    ]
+   },
+   "rust::backtrace": {
+    "name": "backtrace",
+    "path": ".mole.rust_cache/kcshared/backtrace-0.3.73",
+    "version": "0.3.73",
+    "author": "The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/backtrace-0.3.73/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/backtrace-0.3.73/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/backtrace-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "backtrace"
+    ]
+   },
+   "rust::base64": {
+    "name": "base64",
+    "path": ".mole.rust_cache/kcshared/base64-0.22.1",
+    "version": "0.22.1",
+    "author": "Marshall Pierce <marshall@mpierce.org>",
+    "attribution": [
+     "Copyright 2015 Alice Maz"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/base64-0.22.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/base64-0.22.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Alice Maz"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/marshallpierce/rust-base64",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "base64"
+    ]
+   },
+   "rust::bitflags": {
+    "name": "bitflags",
+    "path": ".mole.rust_cache/kcshared/bitflags-2.5.0",
+    "version": "2.5.0",
+    "author": "The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/bitflags-2.5.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/bitflags-2.5.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/bitflags/bitflags",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "bitflags"
+    ]
+   },
+   "rust::block-buffer": {
+    "name": "block-buffer",
+    "path": ".mole.rust_cache/kcshared/block-buffer-0.10.4",
+    "version": "0.10.4",
+    "author": "RustCrypto Developers",
+    "attribution": [
+     "Copyright 2018-2019 The RustCrypto Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/block-buffer-0.10.4/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/block-buffer-0.10.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018-2019 The RustCrypto Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/RustCrypto/utils",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "block-buffer"
+    ]
+   },
+   "rust::bumpalo": {
+    "name": "bumpalo",
+    "path": ".mole.rust_cache/kcshared/bumpalo-3.16.0",
+    "version": "3.16.0",
+    "author": "Nick Fitzgerald <fitzgen@gmail.com>",
+    "attribution": [
+     "Copyright 2019 Nick Fitzgerald"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/bumpalo-3.16.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/bumpalo-3.16.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 Nick Fitzgerald"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/fitzgen/bumpalo",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "bumpalo"
+    ]
+   },
+   "rust::byteorder": {
+    "name": "byteorder",
+    "path": ".mole.rust_cache/kcshared/byteorder-1.5.0",
+    "version": "1.5.0",
+    "author": "Andrew Gallant <jamslam@gmail.com>",
+    "attribution": [
+     "Copyright 2015 Andrew Gallant"
+    ],
+    "licenses": [
+     "MIT",
+     "Unlicense"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/byteorder-1.5.0/COPYING": {
+      "checksum": "18cb1e425a6d45a4e98b6fc3b4d85f85d333862fe906555b2168e8234fefe111",
+      "guess": "MIT",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/byteorder-1.5.0/UNLICENSE": {
+      "checksum": "daa475343600cbb7ef14411d59b1eea77fb8f66c48dcc8cb6cceb9cdbe0c07a9",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/byteorder-1.5.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Andrew Gallant"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/BurntSushi/byteorder",
+    "ltype": "Unlicense OR MIT",
+    "children": [
+     "byteorder"
+    ]
+   },
+   "rust::bytes": {
+    "name": "bytes",
+    "path": ".mole.rust_cache/kcshared/bytes-1.7.1",
+    "version": "1.7.1",
+    "author": "Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2018 Carl Lerche"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/bytes-1.7.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 Carl Lerche"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tokio-rs/bytes",
+    "ltype": "MIT",
+    "children": [
+     "bytes"
+    ]
+   },
+   "rust::cc": {
+    "name": "cc",
+    "path": ".mole.rust_cache/kcshared/cc-1.2.26",
+    "version": "1.2.26",
+    "author": "Alex Crichton <alex@alexcrichton.com>",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/cc-1.2.26/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/cc-1.2.26/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/cc-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "cc"
+    ]
+   },
+   "rust::cfg-if": {
+    "name": "cfg-if",
+    "path": ".mole.rust_cache/kcshared/cfg-if-1.0.0",
+    "version": "1.0.0",
+    "author": "Alex Crichton <alex@alexcrichton.com>",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/cfg-if-1.0.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcshared/cfg-if-1.0.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/alexcrichton/cfg-if",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "cfg-if"
+    ]
+   },
+   "rust::chrono": {
+    "name": "chrono",
+    "path": ".mole.rust_cache/kcshared/chrono-0.4.38",
+    "version": "0.4.38",
+    "attribution": [
+     "Copyright 2014, Kang Seonghoon."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcshared/chrono-0.4.38/LICENSE.txt": {
+      "checksum": "fabe6cb79a51241864d80327919825eccda78e8b982e5a71452f8b6109786196",
+      "attribution": [
+       "Copyright 2014, Kang Seonghoon."
+      ],
+      "multi": true
+     }
+    },
+    "repo": "https://github.com/chronotope/chrono",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "chrono"
+    ]
+   },
+   "rust::clap": {
+    "name": "clap",
+    "path": ".mole.rust_cache/kallichore_api/clap_builder-4.5.13",
+    "version": "4.5.13",
+    "attribution": [
+     "Copyright 2015-2022 Kevin B. Knapp and Clap Contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kallichore_api/clap_builder-4.5.13/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kallichore_api/clap_builder-4.5.13/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015-2022 Kevin B. Knapp and Clap Contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/clap-rs/clap",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "clap_builder",
+     "clap_derive",
+     "clap_lex",
+     "clap"
+    ]
+   },
+   "rust::clap-verbosity-flag": {
+    "name": "clap-verbosity-flag",
+    "path": ".mole.rust_cache/kcserver/clap-verbosity-flag-0.3.2",
+    "version": "0.3.2",
+    "author": "Pascal Hertleif <killercup@gmail.com>",
+    "attribution": [
+     "Copyright 2018 The clap-verbosity-flag Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/clap-verbosity-flag-0.3.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/clap-verbosity-flag-0.3.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 The clap-verbosity-flag Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-clique/clap-verbosity-flag",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "clap-verbosity-flag"
+    ]
+   },
+   "rust::colorchoice": {
+    "name": "colorchoice",
+    "path": ".mole.rust_cache/kcserver/colorchoice-1.0.2",
+    "version": "1.0.2",
+    "attribution": [
+     "Copyright Individual contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/colorchoice-1.0.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/colorchoice-1.0.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright Individual contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-cli/anstyle",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "colorchoice"
+    ]
+   },
+   "rust::colored": {
+    "name": "colored",
+    "path": ".mole.rust_cache/kcserver/colored-2.2.0",
+    "version": "2.2.0",
+    "author": "Thomas Wickham <mackwic@gmail.com>",
+    "licenses": [
+     "MPL-2.0"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/colored-2.2.0/LICENSE": {
+      "checksum": "6220c16f40d2d10bdb2eff01e42c666b171ec2fe6940f2eb3f7e8d95f49c9531",
+      "guess": "MPL-2.0"
+     }
+    },
+    "repo": "https://github.com/mackwic/colored",
+    "ltype": "MPL-2.0",
+    "attribution": [],
+    "children": [
+     "colored"
+    ]
+   },
+   "rust::concurrent-queue": {
+    "name": "concurrent-queue",
+    "path": ".mole.rust_cache/kcserver/concurrent-queue-2.5.0",
+    "version": "2.5.0",
+    "author": "Stjepan Glavina <stjepang@gmail.com>, Taiki Endo <te316e89@gmail.com>, John Nunley <dev@notgull.net>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/concurrent-queue-2.5.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/concurrent-queue-2.5.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/smol-rs/concurrent-queue",
+    "ltype": "Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "concurrent-queue"
+    ]
+   },
+   "rust::console": {
+    "name": "console",
+    "path": ".mole.rust_cache/kcserver/console-0.14.1",
+    "version": "0.14.1",
+    "author": "Armin Ronacher <armin.ronacher@active-4.com>",
+    "attribution": [
+     "Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/console-0.14.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/mitsuhiko/console",
+    "ltype": "MIT",
+    "children": [
+     "console"
+    ]
+   },
+   "rust::core-foundation-rs": {
+    "name": "core-foundation-rs",
+    "path": ".mole.rust_cache/kcserver/core-foundation-0.9.4",
+    "version": "0.9.4",
+    "author": "The Servo Project Developers",
+    "attribution": [
+     "Copyright 2012-2013 Mozilla Foundation"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/core-foundation-0.9.4/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/core-foundation-0.9.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2012-2013 Mozilla Foundation"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/servo/core-foundation-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "core-foundation",
+     "core-foundation-sys"
+    ]
+   },
+   "rust::cpufeatures": {
+    "name": "cpufeatures",
+    "path": ".mole.rust_cache/kcserver/cpufeatures-0.2.13",
+    "version": "0.2.13",
+    "author": "RustCrypto Developers",
+    "attribution": [
+     "Copyright 2020 The RustCrypto Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/cpufeatures-0.2.13/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/cpufeatures-0.2.13/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2020 The RustCrypto Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/RustCrypto/utils",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "cpufeatures"
+    ]
+   },
+   "rust::crossbeam": {
+    "name": "crossbeam",
+    "path": ".mole.rust_cache/kcserver/crossbeam-deque-0.8.5",
+    "version": "0.8.5",
+    "attribution": [
+     "Copyright 2019 The Crossbeam Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/crossbeam-deque-0.8.5/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/crossbeam-deque-0.8.5/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 The Crossbeam Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/crossbeam-rs/crossbeam",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "crossbeam-deque",
+     "crossbeam-epoch",
+     "crossbeam-queue",
+     "crossbeam-utils"
+    ]
+   },
+   "rust::crypto-common": {
+    "name": "crypto-common",
+    "path": ".mole.rust_cache/kcserver/crypto-common-0.1.6",
+    "version": "0.1.6",
+    "author": "RustCrypto Developers",
+    "attribution": [
+     "Copyright 2021 RustCrypto Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/crypto-common-0.1.6/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/crypto-common-0.1.6/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2021 RustCrypto Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/RustCrypto/traits",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "crypto-common"
+    ]
+   },
+   "rust::darling": {
+    "name": "darling",
+    "path": ".mole.rust_cache/kcserver/darling-0.20.10",
+    "version": "0.20.10",
+    "author": "Ted Driggs <ted.driggs@outlook.com>",
+    "attribution": [
+     "Copyright 2017 Ted Driggs"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/darling-0.20.10/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Ted Driggs"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/TedDriggs/darling",
+    "ltype": "MIT",
+    "children": [
+     "darling",
+     "darling_core",
+     "darling_macro"
+    ]
+   },
+   "rust::dashmap": {
+    "name": "dashmap",
+    "path": ".mole.rust_cache/kcserver/dashmap-5.5.3",
+    "version": "5.5.3",
+    "author": "Acrimon <joel.wejdenstal@gmail.com>",
+    "attribution": [
+     "Copyright 2019 Acrimon"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/dashmap-5.5.3/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 Acrimon"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/xacrimon/dashmap",
+    "ltype": "MIT",
+    "children": [
+     "dashmap"
+    ]
+   },
+   "rust::data-encoding": {
+    "name": "data-encoding",
+    "path": ".mole.rust_cache/kcserver/data-encoding-2.6.0",
+    "version": "2.6.0",
+    "author": "Julien Cretin <git@ia0.eu>",
+    "attribution": [
+     "Copyright 2015-2020 Julien Cretin",
+     "Copyright 2017-2020 Google Inc."
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/data-encoding-2.6.0/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015-2020 Julien Cretin",
+       "Copyright 2017-2020 Google Inc."
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/ia0/data-encoding",
+    "ltype": "MIT",
+    "children": [
+     "data-encoding"
+    ]
+   },
+   "rust::deranged": {
+    "name": "deranged",
+    "path": ".mole.rust_cache/kcserver/deranged-0.3.11",
+    "version": "0.3.11",
+    "author": "Jacob Pratt <jacob@jhpratt.dev>",
+    "attribution": [
+     "Copyright 2022 Jacob Pratt et al."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/deranged-0.3.11/LICENSE-Apache": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2022 Jacob Pratt et al."
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/deranged-0.3.11/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2022 Jacob Pratt et al."
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/jhpratt/deranged",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "deranged"
+    ]
+   },
+   "rust::dialoguer": {
+    "name": "dialoguer",
+    "path": ".mole.rust_cache/kcserver/dialoguer-0.8.0",
+    "version": "0.8.0",
+    "author": "Armin Ronacher <armin.ronacher@active-4.com>, Pavan Kumar Sunkara <pavan.sss1991@gmail.com>",
+    "attribution": [
+     "Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/dialoguer-0.8.0/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/mitsuhiko/dialoguer",
+    "ltype": "MIT",
+    "children": [
+     "dialoguer"
+    ]
+   },
+   "rust::digest": {
+    "name": "digest",
+    "path": ".mole.rust_cache/kcserver/digest-0.10.7",
+    "version": "0.10.7",
+    "author": "RustCrypto Developers",
+    "attribution": [
+     "Copyright 2017 Artyom Pavlov"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/digest-0.10.7/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/digest-0.10.7/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Artyom Pavlov"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/RustCrypto/traits",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "digest"
+    ]
+   },
+   "rust::directories": {
+    "name": "directories",
+    "path": ".mole.rust_cache/kcserver/directories-5.0.1",
+    "version": "5.0.1",
+    "author": "Simon Ochsenreither <simon@ochsenreither.de>",
+    "attribution": [
+     "Copyright 2018 directories-rs contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/directories-5.0.1/LICENSE-APACHE": {
+      "checksum": "489e003e7ca32823ec2fd5df4ee29e76e68ac332a77920eb31c1ef70be8f9de2",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/directories-5.0.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 directories-rs contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/soc/directories-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "directories"
+    ]
+   },
+   "rust::dirs-sys": {
+    "name": "dirs-sys",
+    "path": ".mole.rust_cache/kcserver/dirs-sys-0.4.1",
+    "version": "0.4.1",
+    "author": "Simon Ochsenreither <simon@ochsenreither.de>",
+    "attribution": [
+     "Copyright 2018-2019 dirs-rs contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/dirs-sys-0.4.1/LICENSE-APACHE": {
+      "checksum": "489e003e7ca32823ec2fd5df4ee29e76e68ac332a77920eb31c1ef70be8f9de2",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/dirs-sys-0.4.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018-2019 dirs-rs contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/dirs-dev/dirs-sys-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "dirs-sys"
+    ]
+   },
+   "rust::either": {
+    "name": "either",
+    "path": ".mole.rust_cache/kcserver/either-1.12.0",
+    "version": "1.12.0",
+    "author": "bluss",
+    "attribution": [
+     "Copyright 2015 bluss"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/either-1.12.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/either-1.12.0/LICENSE-MIT": {
+      "checksum": "64378261248abaa02c2ffae190e8fe002205d7c85f0674220e5cd53f9b656366",
+      "attribution": [
+       "Copyright 2015 bluss"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rayon-rs/either",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "either"
+    ]
+   },
+   "rust::encode_unicode": {
+    "name": "encode_unicode",
+    "path": ".mole.rust_cache/kcserver/encode_unicode-0.3.6",
+    "version": "0.3.6",
+    "author": "Torbj\u00f8rn Birch Moltu <t.b.moltu@lyse.net>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/encode_unicode-0.3.6/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/encode_unicode-0.3.6/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/tormol/encode_unicode",
+    "ltype": "MIT/Apache-2.0",
+    "attribution": [],
+    "children": [
+     "encode_unicode"
+    ]
+   },
+   "rust::env_logger": {
+    "name": "env_logger",
+    "path": ".mole.rust_cache/kcserver/env_logger-0.11.5",
+    "version": "0.11.5",
+    "attribution": [
+     "Copyright Individual contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/env_logger-0.11.5/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/env_logger-0.11.5/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright Individual contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-cli/env_logger",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "env_filter",
+     "env_logger"
+    ]
+   },
+   "rust::equivalent": {
+    "name": "equivalent",
+    "path": ".mole.rust_cache/kcserver/equivalent-1.0.1",
+    "version": "1.0.1",
+    "attribution": [
+     "Copyright 2016--2023"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/equivalent-1.0.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/equivalent-1.0.1/LICENSE-MIT": {
+      "checksum": "1290e606c99fa8f9f3fc9240c23313ef7e46a1c1ac09a96bb2e6d1fb8eb4a51f",
+      "attribution": [
+       "Copyright 2016--2023"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/cuviper/equivalent",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "equivalent"
+    ]
+   },
+   "rust::errno": {
+    "name": "errno",
+    "path": ".mole.rust_cache/kcserver/errno-0.3.9",
+    "version": "0.3.9",
+    "author": "Chris Wong <lambda.fairy@gmail.com>",
+    "attribution": [
+     "Copyright 2014 Chris Wong"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/errno-0.3.9/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/errno-0.3.9/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Chris Wong"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/lambda-fairy/rust-errno",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "errno"
+    ]
+   },
+   "rust::event-listener": {
+    "name": "event-listener",
+    "path": ".mole.rust_cache/kcserver/event-listener-5.3.1",
+    "version": "5.3.1",
+    "author": "Stjepan Glavina <stjepang@gmail.com>, John Nunley <dev@notgull.net>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/event-listener-5.3.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/event-listener-5.3.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/smol-rs/event-listener",
+    "ltype": "Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "event-listener"
+    ]
+   },
+   "rust::event-listener-strategy": {
+    "name": "event-listener-strategy",
+    "path": ".mole.rust_cache/kcserver/event-listener-strategy-0.5.2",
+    "version": "0.5.2",
+    "author": "John Nunley <dev@notgull.net>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/event-listener-strategy-0.5.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/event-listener-strategy-0.5.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/smol-rs/event-listener-strategy",
+    "ltype": "Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "event-listener-strategy"
+    ]
+   },
+   "rust::fastrand": {
+    "name": "fastrand",
+    "path": ".mole.rust_cache/kcserver/fastrand-2.1.0",
+    "version": "2.1.0",
+    "author": "Stjepan Glavina <stjepang@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/fastrand-2.1.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/fastrand-2.1.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/smol-rs/fastrand",
+    "ltype": "Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "fastrand"
+    ]
+   },
+   "rust::fnv": {
+    "name": "fnv",
+    "path": ".mole.rust_cache/kcserver/fnv-1.0.7",
+    "version": "1.0.7",
+    "author": "Alex Crichton <alex@alexcrichton.com>",
+    "attribution": [
+     "Copyright 2017 Contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/fnv-1.0.7/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/fnv-1.0.7/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/servo/rust-fnv",
+    "ltype": "Apache-2.0 / MIT",
+    "children": [
+     "fnv"
+    ]
+   },
+   "rust::foreign-types": {
+    "name": "foreign-types",
+    "path": ".mole.rust_cache/kcserver/foreign-types-0.3.2",
+    "version": "0.3.2",
+    "author": "Steven Fackler <sfackler@gmail.com>",
+    "attribution": [
+     "Copyright 2017 The foreign-types Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/foreign-types-0.3.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/foreign-types-0.3.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 The foreign-types Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/sfackler/foreign-types",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "foreign-types",
+     "foreign-types-shared"
+    ]
+   },
+   "rust::form_urlencoded": {
+    "name": "form_urlencoded",
+    "path": ".mole.rust_cache/kcserver/form_urlencoded-1.2.1",
+    "version": "1.2.1",
+    "author": "The rust-url developers",
+    "attribution": [
+     "Copyright 2013-2016 The rust-url developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/form_urlencoded-1.2.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/form_urlencoded-1.2.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2013-2016 The rust-url developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/servo/rust-url",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "form_urlencoded"
+    ]
+   },
+   "rust::frunk": {
+    "name": "frunk",
+    "path": ".mole.rust_cache/kallichore_api/frunk_core-0.4.3",
+    "version": "0.4.3",
+    "author": "Lloyd <lloydmeta@gmail.com>",
+    "licenses": [
+     "MIT"
+    ],
+    "repo": "https://github.com/lloydmeta/frunk",
+    "ltype": "MIT",
+    "attribution": [],
+    "children": [
+     "frunk_core",
+     "frunk_derives",
+     "frunk_proc_macro_helpers",
+     "frunk_proc_macros",
+     "frunk"
+    ]
+   },
+   "rust::frunk-enum": {
+    "name": "frunk-enum",
+    "path": ".mole.rust_cache/kcserver/frunk-enum-core-0.3.0",
+    "version": "0.3.0",
+    "author": "Metaswitch Networks Ltd",
+    "attribution": [
+     "Copyright 2018 Metaswitch Networks"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/frunk-enum-core-0.3.0/LICENSE-APACHE-2.0": {
+      "checksum": "5e2bb1e6b78861a8b13150f493003aedab4168a1f338b8d4cea4763255a99ece",
+      "attribution": [
+       "Copyright 2018 Metaswitch Networks"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/frunk-enum-core-0.3.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 Metaswitch Networks"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/Metaswitch/frunk-enum",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "frunk-enum-core",
+     "frunk-enum-derive"
+    ]
+   },
+   "rust::futures-rs": {
+    "name": "futures-rs",
+    "path": ".mole.rust_cache/kcserver/futures-0.3.30",
+    "version": "0.3.30",
+    "attribution": [
+     "Copyright 2016 Alex Crichton",
+     "Copyright 2017 The Tokio Authors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/futures-0.3.30/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2016 Alex Crichton",
+       "Copyright 2017 The Tokio Authors"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/futures-0.3.30/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Alex Crichton",
+       "Copyright 2017 The Tokio Authors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/futures-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "futures",
+     "futures-channel",
+     "futures-core",
+     "futures-executor",
+     "futures-io",
+     "futures-macro",
+     "futures-sink",
+     "futures-task",
+     "futures-util"
+    ]
+   },
+   "rust::generic-array": {
+    "name": "generic-array",
+    "path": ".mole.rust_cache/kcserver/generic-array-0.14.7",
+    "version": "0.14.7",
+    "author": "Bart\u0142omiej Kami\u0144ski <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>",
+    "attribution": [
+     "Copyright 2015 Bart\u0142omiej Kami\u0144ski"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/generic-array-0.14.7/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Bart\u0142omiej Kami\u0144ski"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/fizyk20/generic-array",
+    "ltype": "MIT",
+    "children": [
+     "generic-array"
+    ]
+   },
+   "rust::getrandom": {
+    "name": "getrandom",
+    "path": ".mole.rust_cache/kcserver/getrandom-0.2.15",
+    "version": "0.2.15",
+    "author": "The Rand Project Developers",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers",
+     "Copyright 2018-2024 The rust-random Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/getrandom-0.2.15/LICENSE-APACHE": {
+      "checksum": "4de7ee093135cce839c242afc7cf4a18697970159f885b88ada638164e27bf42",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/getrandom-0.2.15/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers",
+       "Copyright 2018-2024 The rust-random Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-random/getrandom",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "getrandom"
+    ]
+   },
+   "rust::gimli": {
+    "name": "gimli",
+    "path": ".mole.rust_cache/kcserver/gimli-0.29.0",
+    "version": "0.29.0",
+    "attribution": [
+     "Copyright 2015 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/gimli-0.29.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/gimli-0.29.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/gimli-rs/gimli",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "gimli"
+    ]
+   },
+   "rust::h2": {
+    "name": "h2",
+    "path": ".mole.rust_cache/kcserver/h2-0.3.26",
+    "version": "0.3.26",
+    "author": "Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2017 h2 authors"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/h2-0.3.26/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 h2 authors"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/hyperium/h2",
+    "ltype": "MIT",
+    "children": [
+     "h2"
+    ]
+   },
+   "rust::hashbrown": {
+    "name": "hashbrown",
+    "path": ".mole.rust_cache/kcserver/hashbrown-0.14.5",
+    "version": "0.14.5",
+    "author": "Amanieu d'Antras <amanieu@gmail.com>",
+    "attribution": [
+     "Copyright 2016 Amanieu d'Antras"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/hashbrown-0.14.5/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/hashbrown-0.14.5/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Amanieu d'Antras"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/hashbrown",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "hashbrown"
+    ]
+   },
+   "rust::heck": {
+    "name": "heck",
+    "path": ".mole.rust_cache/kcserver/heck-0.5.0",
+    "version": "0.5.0",
+    "attribution": [
+     "Copyright 2015 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/heck-0.5.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/heck-0.5.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/withoutboats/heck",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "heck"
+    ]
+   },
+   "rust::hermit-abi": {
+    "name": "hermit-abi",
+    "path": ".mole.rust_cache/kcserver/hermit-abi-0.3.9",
+    "version": "0.3.9",
+    "author": "Stefan Lankes",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/hermit-abi-0.3.9/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/hermit-abi-0.3.9/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/hermit-os/hermit-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "hermit-abi"
+    ]
+   },
+   "rust::hex": {
+    "name": "hex",
+    "path": ".mole.rust_cache/kcserver/hex-0.4.3",
+    "version": "0.4.3",
+    "author": "KokaKiwi <kokakiwi@kokakiwi.net>",
+    "attribution": [
+     "Copyright 2013-2014 The Rust Project Developers.",
+     "Copyright 2015-2020 The rust-hex Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/hex-0.4.3/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/hex-0.4.3/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2013-2014 The Rust Project Developers.",
+       "Copyright 2015-2020 The rust-hex Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/KokaKiwi/rust-hex",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "hex"
+    ]
+   },
+   "rust::hmac": {
+    "name": "hmac",
+    "path": ".mole.rust_cache/kcserver/hmac-0.12.1",
+    "version": "0.12.1",
+    "author": "RustCrypto Developers",
+    "attribution": [
+     "Copyright 2017 Artyom Pavlov"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/hmac-0.12.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/hmac-0.12.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Artyom Pavlov"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/RustCrypto/MACs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "hmac"
+    ]
+   },
+   "rust::http": {
+    "name": "http",
+    "path": ".mole.rust_cache/kcserver/http-1.1.0",
+    "version": "1.1.0",
+    "author": "Alex Crichton <alex@alexcrichton.com>, Carl Lerche <me@carllerche.com>, Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2017 http-rs authors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/http-1.1.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2017 http-rs authors"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/http-1.1.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 http-rs authors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/hyperium/http",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "http"
+    ]
+   },
+   "rust::http-body": {
+    "name": "http-body",
+    "path": ".mole.rust_cache/kcserver/http-body-1.0.1",
+    "version": "1.0.1",
+    "author": "Carl Lerche <me@carllerche.com>, Lucio Franco <luciofranco14@gmail.com>, Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2019-2024 Sean McArthur & Hyper Contributors"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/http-body-1.0.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019-2024 Sean McArthur & Hyper Contributors"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/hyperium/http-body",
+    "ltype": "MIT",
+    "children": [
+     "http-body"
+    ]
+   },
+   "rust::httparse": {
+    "name": "httparse",
+    "path": ".mole.rust_cache/kcserver/httparse-1.9.4",
+    "version": "1.9.4",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2015-2024 Sean McArthur"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/httparse-1.9.4/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/httparse-1.9.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015-2024 Sean McArthur"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/seanmonstar/httparse",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "httparse"
+    ]
+   },
+   "rust::httpdate": {
+    "name": "httpdate",
+    "path": ".mole.rust_cache/kcserver/httpdate-1.0.3",
+    "version": "1.0.3",
+    "author": "Pyfisch <pyfisch@posteo.org>",
+    "attribution": [
+     "Copyright 2016 Pyfisch"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/httpdate-1.0.3/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/httpdate-1.0.3/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Pyfisch"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/pyfisch/httpdate",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "httpdate"
+    ]
+   },
+   "rust::humantime": {
+    "name": "humantime",
+    "path": ".mole.rust_cache/kcserver/humantime-2.1.0",
+    "version": "2.1.0",
+    "author": "Paul Colomiets <paul@colomiets.name>",
+    "attribution": [
+     "Copyright 2016 Pyfisch",
+     "Copyright 2016 The humantime Developers",
+     "Copyright \u00a9 2005-2013 Rich Felker"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/humantime-2.1.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/humantime-2.1.0/LICENSE-MIT": {
+      "checksum": "f499aaebf8c639c0545cff012fe4d4d0946f0322e64bedcc40344d0f151714a9",
+      "attribution": [
+       "Copyright 2016 Pyfisch",
+       "Copyright 2016 The humantime Developers",
+       "Copyright \u00a9 2005-2013 Rich Felker"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tailhook/humantime",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "humantime"
+    ]
+   },
+   "rust::hyper": {
+    "name": "hyper",
+    "path": ".mole.rust_cache/kcserver/hyper-1.4.1",
+    "version": "1.4.1",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2014-2021 Sean McArthur"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/hyper-1.4.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014-2021 Sean McArthur"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/hyperium/hyper",
+    "ltype": "MIT",
+    "children": [
+     "hyper"
+    ]
+   },
+   "rust::hyper-old-types": {
+    "name": "hyper-old-types",
+    "path": ".mole.rust_cache/kcserver/hyper-old-types-0.11.0",
+    "version": "0.11.0",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2014 Sean McArthur"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/hyper-old-types-0.11.0/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Sean McArthur"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/hyperium/hyper-old-types",
+    "ltype": "MIT",
+    "children": [
+     "hyper-old-types"
+    ]
+   },
+   "rust::hyper-util": {
+    "name": "hyper-util",
+    "path": ".mole.rust_cache/kcserver/hyper-util-0.1.7",
+    "version": "0.1.7",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2023 Sean McArthur"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/hyper-util-0.1.7/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2023 Sean McArthur"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/hyperium/hyper-util",
+    "ltype": "MIT",
+    "children": [
+     "hyper-util"
+    ]
+   },
+   "rust::hyperlocal": {
+    "name": "hyperlocal",
+    "path": ".mole.rust_cache/kcserver/hyperlocal-0.8.0",
+    "version": "0.8.0",
+    "author": "softprops <d.tangren@gmail.com>",
+    "attribution": [
+     "Copyright 2015-2020 Doug Tangren"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/hyperlocal-0.8.0/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015-2020 Doug Tangren"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/softprops/hyperlocal",
+    "ltype": "MIT",
+    "children": [
+     "hyperlocal"
+    ]
+   },
+   "rust::iana-time-zone": {
+    "name": "iana-time-zone",
+    "path": ".mole.rust_cache/kcserver/iana-time-zone-0.1.60",
+    "version": "0.1.60",
+    "author": "Andrew Straw <strawman@astraw.com>, Ren\u00e9 Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>",
+    "attribution": [
+     "Copyright 2020 Andrew D. Straw",
+     "Copyright 2020 Andrew Straw"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/iana-time-zone-0.1.60/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2020 Andrew Straw"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/iana-time-zone-0.1.60/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2020 Andrew D. Straw"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/strawlab/iana-time-zone",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "iana-time-zone",
+     "iana-time-zone-haiku"
+    ]
+   },
+   "rust::ident_case": {
+    "name": "ident_case",
+    "path": ".mole.rust_cache/kcserver/ident_case-1.0.1",
+    "version": "1.0.1",
+    "author": "Ted Driggs <ted.driggs@outlook.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/ident_case-1.0.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/TedDriggs/ident_case",
+    "ltype": "MIT/Apache-2.0",
+    "attribution": [],
+    "children": [
+     "ident_case"
+    ]
+   },
+   "rust::rust-url": {
+    "name": "rust-url",
+    "path": ".mole.rust_cache/kcserver/idna-0.5.0",
+    "version": "0.5.0",
+    "author": "The rust-url developers",
+    "attribution": [
+     "Copyright 2013-2022 The rust-url developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/idna-0.5.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/idna-0.5.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2013-2022 The rust-url developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/servo/rust-url/",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "idna",
+     "percent-encoding"
+    ]
+   },
+   "rust::if_chain": {
+    "name": "if_chain",
+    "path": ".mole.rust_cache/kcserver/if_chain-1.0.2",
+    "version": "1.0.2",
+    "author": "Chris Wong <lambda.fairy@gmail.com>",
+    "attribution": [
+     "Copyright 2018 Chris Wong"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/if_chain-1.0.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/if_chain-1.0.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 Chris Wong"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/lambda-fairy/if_chain",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "if_chain"
+    ]
+   },
+   "rust::indexmap": {
+    "name": "indexmap",
+    "path": ".mole.rust_cache/kcserver/indexmap-2.2.6",
+    "version": "2.2.6",
+    "attribution": [
+     "Copyright 2016--2017"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/indexmap-2.2.6/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/indexmap-2.2.6/LICENSE-MIT": {
+      "checksum": "1290e606c99fa8f9f3fc9240c23313ef7e46a1c1ac09a96bb2e6d1fb8eb4a51f",
+      "attribution": [
+       "Copyright 2016--2017"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/indexmap-rs/indexmap",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "indexmap"
+    ]
+   },
+   "rust::iovec": {
+    "name": "iovec",
+    "path": ".mole.rust_cache/kcserver/iovec-0.1.4",
+    "version": "0.1.4",
+    "author": "Carl Lerche <me@carllerche.com>",
+    "attribution": [
+     "Copyright 2017 Carl Lerche"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/iovec-0.1.4/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2017 Carl Lerche"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/iovec-0.1.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Carl Lerche"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/carllerche/iovec",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "iovec"
+    ]
+   },
+   "rust::is_terminal_polyfill": {
+    "name": "is_terminal_polyfill",
+    "path": ".mole.rust_cache/kcserver/is_terminal_polyfill-1.70.1",
+    "version": "1.70.1",
+    "attribution": [
+     "Copyright Individual contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/is_terminal_polyfill-1.70.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/is_terminal_polyfill-1.70.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright Individual contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/polyfill-rs/is_terminal_polyfill",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "is_terminal_polyfill"
+    ]
+   },
+   "rust::itertools": {
+    "name": "itertools",
+    "path": ".mole.rust_cache/kcserver/itertools-0.12.1",
+    "version": "0.12.1",
+    "author": "bluss",
+    "attribution": [
+     "Copyright 2015 bluss"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/itertools-0.12.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/itertools-0.12.1/LICENSE-MIT": {
+      "checksum": "64378261248abaa02c2ffae190e8fe002205d7c85f0674220e5cd53f9b656366",
+      "attribution": [
+       "Copyright 2015 bluss"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-itertools/itertools",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "itertools"
+    ]
+   },
+   "rust::itoa": {
+    "name": "itoa",
+    "path": ".mole.rust_cache/kcserver/itoa-1.0.11",
+    "version": "1.0.11",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/itoa-1.0.11/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/itoa-1.0.11/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/itoa",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "itoa"
+    ]
+   },
+   "rust::wasm-bindgen": {
+    "name": "wasm-bindgen",
+    "path": ".mole.rust_cache/kcserver/wasm-bindgen-0.2.92",
+    "version": "0.2.92",
+    "author": "The wasm-bindgen Developers",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/wasm-bindgen-0.2.92/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/wasm-bindgen-0.2.92/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rustwasm/wasm-bindgen",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "js-sys",
+     "wasm-bindgen",
+     "wasm-bindgen-backend",
+     "wasm-bindgen-macro",
+     "wasm-bindgen-macro-support",
+     "wasm-bindgen-shared"
+    ]
+   },
+   "rust::jsonwebtoken": {
+    "name": "jsonwebtoken",
+    "path": ".mole.rust_cache/kcserver/jsonwebtoken-9.3.1",
+    "version": "9.3.1",
+    "author": "Vincent Prouillet <hello@vincentprouillet.com>",
+    "attribution": [
+     "Copyright 2015 Vincent Prouillet"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/jsonwebtoken-9.3.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Vincent Prouillet"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/Keats/jsonwebtoken",
+    "ltype": "MIT",
+    "children": [
+     "jsonwebtoken"
+    ]
+   },
+   "rust::language-tags": {
+    "name": "language-tags",
+    "path": ".mole.rust_cache/kcserver/language-tags-0.2.2",
+    "version": "0.2.2",
+    "author": "Pyfisch <pyfisch@gmail.com>",
+    "attribution": [
+     "Copyright 2015 Pyfisch"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/language-tags-0.2.2/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Pyfisch"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/pyfisch/rust-language-tags",
+    "ltype": "MIT",
+    "children": [
+     "language-tags"
+    ]
+   },
+   "rust::lazy_static": {
+    "name": "lazy_static",
+    "path": ".mole.rust_cache/kcserver/lazy_static-1.5.0",
+    "version": "1.5.0",
+    "author": "Marvin L\u00f6bel <loebel.marvin@gmail.com>",
+    "attribution": [
+     "Copyright 2010 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/lazy_static-1.5.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/lazy_static-1.5.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2010 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang-nursery/lazy-static.rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "lazy_static"
+    ]
+   },
+   "rust::libc": {
+    "name": "libc",
+    "path": ".mole.rust_cache/kcserver/libc-0.2.155",
+    "version": "0.2.155",
+    "author": "The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014-2020 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/libc-0.2.155/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/libc-0.2.155/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014-2020 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/libc",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "libc"
+    ]
+   },
+   "rust::libredox": {
+    "name": "libredox",
+    "path": ".mole.rust_cache/kcserver/libredox-0.1.3",
+    "version": "0.1.3",
+    "author": "4lDO2 <4lDO2@protonmail.com>",
+    "attribution": [
+     "Copyright 2023 4lDO2"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/libredox-0.1.3/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2023 4lDO2"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://gitlab.redox-os.org/redox-os/libredox.git",
+    "ltype": "MIT",
+    "children": [
+     "libredox"
+    ]
+   },
+   "rust::linux-raw-sys": {
+    "name": "linux-raw-sys",
+    "path": ".mole.rust_cache/kcserver/linux-raw-sys-0.4.14",
+    "version": "0.4.14",
+    "author": "Dan Gohman <dev@sunfishcode.online>",
+    "licenses": [
+     "Apache-2.0",
+     "Apache-2.0 WITH LLVM-exception",
+     "Apache-2.0-WITH-LLVM-Exceptions",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/linux-raw-sys-0.4.14/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/linux-raw-sys-0.4.14/LICENSE-Apache-2.0_WITH_LLVM-exception": {
+      "checksum": "ae5b2e89f93f2cd35ca2cce86976b63eb6f7c4b52999aa096fe2d29ee59f86bc",
+      "spdx": [
+       "Apache-2.0-WITH-LLVM-Exceptions"
+      ],
+      "guess": "Apache-2.0-WITH-LLVM-Exceptions",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/linux-raw-sys-0.4.14/COPYRIGHT": {
+      "checksum": "c71b521f017623369c79563b5b0e3ad45b746da048434580cc07b15710f26b14",
+      "multi": true,
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/linux-raw-sys-0.4.14/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/sunfishcode/linux-raw-sys",
+    "ltype": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "linux-raw-sys"
+    ]
+   },
+   "rust::parking_lot": {
+    "name": "parking_lot",
+    "path": ".mole.rust_cache/kcserver/parking_lot-0.12.3",
+    "version": "0.12.3",
+    "author": "Amanieu d'Antras <amanieu@gmail.com>",
+    "attribution": [
+     "Copyright 2016 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/parking_lot-0.12.3/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/parking_lot-0.12.3/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/Amanieu/parking_lot",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "lock_api",
+     "parking_lot",
+     "parking_lot_core"
+    ]
+   },
+   "rust::log": {
+    "name": "log",
+    "path": ".mole.rust_cache/kcserver/log-0.4.21",
+    "version": "0.4.21",
+    "author": "The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/log-0.4.21/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/log-0.4.21/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/log",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "log"
+    ]
+   },
+   "rust::memchr": {
+    "name": "memchr",
+    "path": ".mole.rust_cache/kcserver/memchr-2.7.4",
+    "version": "2.7.4",
+    "author": "Andrew Gallant <jamslam@gmail.com>, bluss",
+    "attribution": [
+     "Copyright 2015 Andrew Gallant"
+    ],
+    "licenses": [
+     "MIT",
+     "Unlicense"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/memchr-2.7.4/COPYING": {
+      "checksum": "18cb1e425a6d45a4e98b6fc3b4d85f85d333862fe906555b2168e8234fefe111",
+      "guess": "MIT",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/memchr-2.7.4/UNLICENSE": {
+      "checksum": "daa475343600cbb7ef14411d59b1eea77fb8f66c48dcc8cb6cceb9cdbe0c07a9",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/memchr-2.7.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Andrew Gallant"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/BurntSushi/memchr",
+    "ltype": "Unlicense OR MIT",
+    "children": [
+     "memchr"
+    ]
+   },
+   "rust::mime": {
+    "name": "mime",
+    "path": ".mole.rust_cache/kcserver/mime-0.3.17",
+    "version": "0.3.17",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2014 Sean McArthur"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/mime-0.3.17/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/mime-0.3.17/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Sean McArthur"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/hyperium/mime",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "mime"
+    ]
+   },
+   "rust::miniz_oxide": {
+    "name": "miniz_oxide",
+    "path": ".mole.rust_cache/kcserver/miniz_oxide-0.7.4",
+    "version": "0.7.4",
+    "author": "Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>",
+    "attribution": [
+     "Copyright 2017 Frommi",
+     "Copyright 2020 Frommi"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT",
+     "Zlib"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/miniz_oxide-0.7.4/LICENSE-MIT.md": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Frommi"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     },
+     ".mole.rust_cache/kcserver/miniz_oxide-0.7.4/LICENSE-ZLIB.md": {
+      "checksum": "d1a157d7f695f1e9a3b2db78e734ba809eebae72b109db34d64a90c91759d568",
+      "attribution": [
+       "Copyright 2020 Frommi"
+      ]
+     },
+     ".mole.rust_cache/kcserver/miniz_oxide-0.7.4/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Frommi"
+      ],
+      "guess": "MIT"
+     },
+     ".mole.rust_cache/kcserver/miniz_oxide-0.7.4/LICENSE-APACHE.md": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/Frommi/miniz_oxide",
+    "ltype": "MIT OR Zlib OR Apache-2.0",
+    "children": [
+     "miniz_oxide"
+    ]
+   },
+   "rust::mio": {
+    "name": "mio",
+    "path": ".mole.rust_cache/kcserver/mio-0.8.11",
+    "version": "0.8.11",
+    "author": "Carl Lerche <me@carllerche.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>, Tokio Contributors <team@tokio.rs>",
+    "attribution": [
+     "Copyright 2014 Carl Lerche and other MIO contributors"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/mio-0.8.11/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Carl Lerche and other MIO contributors"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tokio-rs/mio",
+    "ltype": "MIT",
+    "children": [
+     "mio"
+    ]
+   },
+   "rust::native-tls": {
+    "name": "native-tls",
+    "path": ".mole.rust_cache/kcserver/native-tls-0.2.12",
+    "version": "0.2.12",
+    "author": "Steven Fackler <sfackler@gmail.com>",
+    "attribution": [
+     "Copyright 2016 The rust-native-tls Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/native-tls-0.2.12/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/native-tls-0.2.12/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 The rust-native-tls Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/sfackler/rust-native-tls",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "native-tls"
+    ]
+   },
+   "rust::ntapi": {
+    "name": "ntapi",
+    "path": ".mole.rust_cache/kcserver/ntapi-0.4.1",
+    "version": "0.4.1",
+    "author": "MSxDOS <melcodos@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/ntapi-0.4.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/ntapi-0.4.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/MSxDOS/ntapi",
+    "ltype": "Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "ntapi"
+    ]
+   },
+   "rust::num-bigint": {
+    "name": "num-bigint",
+    "path": ".mole.rust_cache/kcserver/num-bigint-0.4.6",
+    "version": "0.4.6",
+    "author": "The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/num-bigint-0.4.6/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/num-bigint-0.4.6/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-num/num-bigint",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "num-bigint"
+    ]
+   },
+   "rust::num-conv": {
+    "name": "num-conv",
+    "path": ".mole.rust_cache/kcserver/num-conv-0.1.0",
+    "version": "0.1.0",
+    "author": "Jacob Pratt <jacob@jhpratt.dev>",
+    "attribution": [
+     "Copyright 2023 Jacob Pratt"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/num-conv-0.1.0/LICENSE-Apache": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2023 Jacob Pratt"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/num-conv-0.1.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2023 Jacob Pratt"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/jhpratt/num-conv",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "num-conv"
+    ]
+   },
+   "rust::num-integer": {
+    "name": "num-integer",
+    "path": ".mole.rust_cache/kcserver/num-integer-0.1.46",
+    "version": "0.1.46",
+    "author": "The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/num-integer-0.1.46/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/num-integer-0.1.46/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-num/num-integer",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "num-integer"
+    ]
+   },
+   "rust::num-traits": {
+    "name": "num-traits",
+    "path": ".mole.rust_cache/kcserver/num-traits-0.2.19",
+    "version": "0.2.19",
+    "author": "The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/num-traits-0.2.19/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/num-traits-0.2.19/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-num/num-traits",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "num-traits"
+    ]
+   },
+   "rust::num_cpus": {
+    "name": "num_cpus",
+    "path": ".mole.rust_cache/kcserver/num_cpus-1.16.0",
+    "version": "1.16.0",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2015 Sean McArthur <sean@seanmonstar.com>"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/num_cpus-1.16.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/num_cpus-1.16.0/LICENSE-MIT": {
+      "checksum": "64378261248abaa02c2ffae190e8fe002205d7c85f0674220e5cd53f9b656366",
+      "attribution": [
+       "Copyright 2015 Sean McArthur <sean@seanmonstar.com>"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/seanmonstar/num_cpus",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "num_cpus"
+    ]
+   },
+   "rust::num_threads": {
+    "name": "num_threads",
+    "path": ".mole.rust_cache/kcserver/num_threads-0.1.7",
+    "version": "0.1.7",
+    "author": "Jacob Pratt <open-source@jhpratt.dev>",
+    "attribution": [
+     "Copyright 2021 Jacob Pratt"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/num_threads-0.1.7/LICENSE-Apache": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2021 Jacob Pratt"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/num_threads-0.1.7/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2021 Jacob Pratt"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/jhpratt/num_threads",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "num_threads"
+    ]
+   },
+   "rust::object": {
+    "name": "object",
+    "path": ".mole.rust_cache/kcserver/object-0.36.0",
+    "version": "0.36.0",
+    "attribution": [
+     "Copyright 2015 The Gimli Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/object-0.36.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/object-0.36.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The Gimli Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/gimli-rs/object",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "object"
+    ]
+   },
+   "rust::once_cell": {
+    "name": "once_cell",
+    "path": ".mole.rust_cache/kcserver/once_cell-1.20.2",
+    "version": "1.20.2",
+    "author": "Aleksey Kladov <aleksey.kladov@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/once_cell-1.20.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/once_cell-1.20.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/matklad/once_cell",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "once_cell"
+    ]
+   },
+   "rust::openssl": {
+    "name": "openssl",
+    "path": ".mole.rust_cache/kcserver/openssl-0.10.64",
+    "version": "0.10.64",
+    "author": "Steven Fackler <sfackler@gmail.com>",
+    "attribution": [
+     "Copyright 2011-2017 Google Inc. 2013 Jack Lloyd 2013-2014 Steven Fackler"
+    ],
+    "licenses": [
+     "Apache-2.0"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/openssl-0.10.64/LICENSE": {
+      "checksum": "5e2bb1e6b78861a8b13150f493003aedab4168a1f338b8d4cea4763255a99ece",
+      "attribution": [
+       "Copyright 2011-2017 Google Inc. 2013 Jack Lloyd 2013-2014 Steven Fackler"
+      ]
+     }
+    },
+    "repo": "https://github.com/sfackler/rust-openssl",
+    "ltype": "Apache-2.0",
+    "children": [
+     "openssl"
+    ]
+   },
+   "rust::openssl-macros": {
+    "name": "openssl-macros",
+    "path": ".mole.rust_cache/kcserver/openssl-macros-0.1.1",
+    "version": "0.1.1",
+    "attribution": [
+     "Copyright 2022 Steven Fackler"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/openssl-macros-0.1.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/openssl-macros-0.1.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2022 Steven Fackler"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "openssl-macros"
+    ]
+   },
+   "rust::openssl-probe": {
+    "name": "openssl-probe",
+    "path": ".mole.rust_cache/kcserver/openssl-probe-0.1.5",
+    "version": "0.1.5",
+    "author": "Alex Crichton <alex@alexcrichton.com>",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/openssl-probe-0.1.5/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/openssl-probe-0.1.5/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/alexcrichton/openssl-probe",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "openssl-probe"
+    ]
+   },
+   "rust::openssl-sys": {
+    "name": "openssl-sys",
+    "path": ".mole.rust_cache/kcserver/openssl-sys-0.9.102",
+    "version": "0.9.102",
+    "author": "Alex Crichton <alex@alexcrichton.com>, Steven Fackler <sfackler@gmail.com>",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/openssl-sys-0.9.102/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/sfackler/rust-openssl",
+    "ltype": "MIT",
+    "children": [
+     "openssl-sys"
+    ]
+   },
+   "rust::option-ext": {
+    "name": "option-ext",
+    "path": ".mole.rust_cache/kcserver/option-ext-0.2.0",
+    "version": "0.2.0",
+    "author": "Simon Ochsenreither <simon@ochsenreither.de>",
+    "licenses": [
+     "MPL-2.0"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/option-ext-0.2.0/LICENSE.txt": {
+      "checksum": "916da3be9df2937a418401d0f14109d3f9d881468bcbeb33c08a8054c6397aa2",
+      "guess": "MPL-2.0"
+     }
+    },
+    "repo": "https://github.com/soc/option-ext",
+    "ltype": "MPL-2.0",
+    "attribution": [],
+    "children": [
+     "option-ext"
+    ]
+   },
+   "rust::parking": {
+    "name": "parking",
+    "path": ".mole.rust_cache/kcserver/parking-2.2.0",
+    "version": "2.2.0",
+    "author": "Stjepan Glavina <stjepang@gmail.com>, The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014-2020 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/parking-2.2.0/LICENSE-THIRD-PARTY": {
+      "checksum": "0355e3d5c06110f233cace36ca64b1f08e8e918b3d9da4a0656d25b72a946c7b",
+      "attribution": [
+       "Copyright 2014-2020 The Rust Project Developers"
+      ],
+      "multi": true
+     },
+     ".mole.rust_cache/kcserver/parking-2.2.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/parking-2.2.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/smol-rs/parking",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "parking"
+    ]
+   },
+   "rust::pem": {
+    "name": "pem",
+    "path": ".mole.rust_cache/kcserver/pem-3.0.5",
+    "version": "3.0.5",
+    "author": "Jonathan Creekmore <jonathan@thecreekmores.org>",
+    "attribution": [
+     "Copyright 2016 Jonathan Creekmore"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/pem-3.0.5/LICENSE.md": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Jonathan Creekmore"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/jcreekmore/pem-rs",
+    "ltype": "MIT",
+    "children": [
+     "pem"
+    ]
+   },
+   "rust::pin-project": {
+    "name": "pin-project",
+    "path": ".mole.rust_cache/kcserver/pin-project-1.1.10",
+    "version": "1.1.10",
+    "author": "Taiki Endo",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/pin-project-1.1.10/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/pin-project-1.1.10/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/taiki-e/pin-project",
+    "ltype": "Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "pin-project",
+     "pin-project-internal"
+    ]
+   },
+   "rust::pin-project-lite": {
+    "name": "pin-project-lite",
+    "path": ".mole.rust_cache/kcserver/pin-project-lite-0.2.14",
+    "version": "0.2.14",
+    "author": "Taiki Endo",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/pin-project-lite-0.2.14/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/pin-project-lite-0.2.14/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/taiki-e/pin-project-lite",
+    "ltype": "Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "pin-project-lite"
+    ]
+   },
+   "rust::pin-utils": {
+    "name": "pin-utils",
+    "path": ".mole.rust_cache/kcserver/pin-utils-0.1.0",
+    "version": "0.1.0",
+    "author": "Josef Brandl <mail@josefbrandl.de>",
+    "attribution": [
+     "Copyright 2018 The pin-utils authors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/pin-utils-0.1.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2018 The pin-utils authors"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/pin-utils-0.1.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 The pin-utils authors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang-nursery/pin-utils",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "pin-utils"
+    ]
+   },
+   "rust::pkg-config": {
+    "name": "pkg-config",
+    "path": ".mole.rust_cache/kcserver/pkg-config-0.3.30",
+    "version": "0.3.30",
+    "author": "Alex Crichton <alex@alexcrichton.com>",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/pkg-config-0.3.30/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/pkg-config-0.3.30/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/pkg-config-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "pkg-config"
+    ]
+   },
+   "rust::powerfmt": {
+    "name": "powerfmt",
+    "path": ".mole.rust_cache/kcserver/powerfmt-0.2.0",
+    "version": "0.2.0",
+    "author": "Jacob Pratt <jacob@jhpratt.dev>",
+    "attribution": [
+     "Copyright 2023 Jacob Pratt et al."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/powerfmt-0.2.0/LICENSE-Apache": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2023 Jacob Pratt et al."
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/powerfmt-0.2.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2023 Jacob Pratt et al."
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/jhpratt/powerfmt",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "powerfmt"
+    ]
+   },
+   "rust::ppv-lite86": {
+    "name": "ppv-lite86",
+    "path": ".mole.rust_cache/kcserver/ppv-lite86-0.2.20",
+    "version": "0.2.20",
+    "author": "The CryptoCorrosion Contributors",
+    "attribution": [
+     "Copyright 2019 The CryptoCorrosion Contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/ppv-lite86-0.2.20/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2019 The CryptoCorrosion Contributors"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/ppv-lite86-0.2.20/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 The CryptoCorrosion Contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/cryptocorrosion/cryptocorrosion",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "ppv-lite86"
+    ]
+   },
+   "rust::proc-macro-error": {
+    "name": "proc-macro-error",
+    "path": ".mole.rust_cache/kcserver/proc-macro-error-1.0.4",
+    "version": "1.0.4",
+    "author": "CreepySkeleton <creepy-skeleton@yandex.ru>",
+    "attribution": [
+     "Copyright 2019-2020 CreepySkeleton <creepy-skeleton@yandex.ru>"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/proc-macro-error-1.0.4/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2019-2020 CreepySkeleton <creepy-skeleton@yandex.ru>"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/proc-macro-error-1.0.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019-2020 CreepySkeleton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://gitlab.com/CreepySkeleton/proc-macro-error",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "proc-macro-error",
+     "proc-macro-error-attr"
+    ]
+   },
+   "rust::proc-macro2": {
+    "name": "proc-macro2",
+    "path": ".mole.rust_cache/kcserver/proc-macro2-1.0.95",
+    "version": "1.0.95",
+    "author": "David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/proc-macro2-1.0.95/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/proc-macro2-1.0.95/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/proc-macro2",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "proc-macro2"
+    ]
+   },
+   "rust::quote": {
+    "name": "quote",
+    "path": ".mole.rust_cache/kcserver/quote-1.0.36",
+    "version": "1.0.36",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/quote-1.0.36/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/quote-1.0.36/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/quote",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "quote"
+    ]
+   },
+   "rust::rand": {
+    "name": "rand",
+    "path": ".mole.rust_cache/kcserver/rand-0.8.5",
+    "version": "0.8.5",
+    "author": "The Rand Project Developers, The Rust Project Developers",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers",
+     "Copyright 2018 Developers of the Rand project"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/rand-0.8.5/LICENSE-APACHE": {
+      "checksum": "ea2f2e0ac9806388b70f309cdd195cb6cbed5b76242bedee244af17813236cb7",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/rand-0.8.5/COPYRIGHT": {
+      "checksum": "c49a013e0cd2d33c0811c015aff438ef025420c68b207522c5810b7d1d67dbb2",
+      "multi": true,
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/rand-0.8.5/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers",
+       "Copyright 2018 Developers of the Rand project"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-random/rand",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "rand",
+     "rand_chacha",
+     "rand_core"
+    ]
+   },
+   "rust::rayon": {
+    "name": "rayon",
+    "path": ".mole.rust_cache/kcserver/rayon-1.10.0",
+    "version": "1.10.0",
+    "author": "Niko Matsakis <niko@alum.mit.edu>, Josh Stone <cuviper@gmail.com>",
+    "attribution": [
+     "Copyright 2010 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/rayon-1.10.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/rayon-1.10.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2010 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rayon-rs/rayon",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "rayon",
+     "rayon-core"
+    ]
+   },
+   "rust::redox_syscall": {
+    "name": "redox_syscall",
+    "path": ".mole.rust_cache/kcserver/redox_syscall-0.5.2",
+    "version": "0.5.2",
+    "author": "Jeremy Soller <jackpot51@gmail.com>",
+    "attribution": [
+     "Copyright 2017 Redox OS Developers"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/redox_syscall-0.5.2/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Redox OS Developers"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://gitlab.redox-os.org/redox-os/syscall",
+    "ltype": "MIT",
+    "children": [
+     "redox_syscall"
+    ]
+   },
+   "rust::redox_users": {
+    "name": "redox_users",
+    "path": ".mole.rust_cache/kcserver/redox_users-0.4.6",
+    "version": "0.4.6",
+    "author": "Jose Narvaez <goyox86@gmail.com>, Wesley Hershberger <mggmugginsmc@gmail.com>",
+    "attribution": [
+     "Copyright 2017 Jose Narvaez"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/redox_users-0.4.6/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Jose Narvaez"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://gitlab.redox-os.org/redox-os/users",
+    "ltype": "MIT",
+    "children": [
+     "redox_users"
+    ]
+   },
+   "rust::regex": {
+    "name": "regex",
+    "path": ".mole.rust_cache/kcserver/regex-1.10.5",
+    "version": "1.10.5",
+    "author": "The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/regex-1.10.5/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/regex-1.10.5/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/regex",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "regex",
+     "regex-automata",
+     "regex-syntax"
+    ]
+   },
+   "rust::ring": {
+    "name": "ring",
+    "path": ".mole.rust_cache/kcserver/ring-0.17.14",
+    "version": "0.17.14",
+    "licenses": [
+     "Apache-2.0",
+     "BoringSSL",
+     "ISC",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/ring-0.17.14/LICENSE": {
+      "checksum": "6dc88adeed58603505474addd32d0b9017cff170801a46a9f61df09cfec260fc",
+      "multi": true,
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/briansmith/ring",
+    "ltype": "Apache-2.0 AND ISC",
+    "attribution": [
+     "Copyright 2009 The Go Authors.",
+     "Copyright 2015 The Chromium Authors.",
+     "Copyright 2015-2025 Brian Smith."
+    ],
+    "children": [
+     "ring"
+    ]
+   },
+   "rust::rustc-demangle": {
+    "name": "rustc-demangle",
+    "path": ".mole.rust_cache/kcserver/rustc-demangle-0.1.24",
+    "version": "0.1.24",
+    "author": "Alex Crichton <alex@alexcrichton.com>",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/rustc-demangle-0.1.24/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/rustc-demangle-0.1.24/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/rustc-demangle",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "rustc-demangle"
+    ]
+   },
+   "rust::rustix": {
+    "name": "rustix",
+    "path": ".mole.rust_cache/kcserver/rustix-0.38.34",
+    "version": "0.38.34",
+    "author": "Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>",
+    "licenses": [
+     "Apache-2.0",
+     "Apache-2.0 WITH LLVM-exception",
+     "Apache-2.0-WITH-LLVM-Exceptions",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/rustix-0.38.34/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/rustix-0.38.34/LICENSE-Apache-2.0_WITH_LLVM-exception": {
+      "checksum": "ae5b2e89f93f2cd35ca2cce86976b63eb6f7c4b52999aa096fe2d29ee59f86bc",
+      "spdx": [
+       "Apache-2.0-WITH-LLVM-Exceptions"
+      ],
+      "guess": "Apache-2.0-WITH-LLVM-Exceptions",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/rustix-0.38.34/COPYRIGHT": {
+      "checksum": "af933c5fc6ce2cf61f73c33864e85e88633a246e415eded7f32036f81e2216dd",
+      "multi": true,
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/rustix-0.38.34/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/bytecodealliance/rustix",
+    "ltype": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "rustix"
+    ]
+   },
+   "rust::ryu": {
+    "name": "ryu",
+    "path": ".mole.rust_cache/kcserver/ryu-1.0.18",
+    "version": "1.0.18",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "BSL-1.0"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/ryu-1.0.18/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/ryu-1.0.18/LICENSE-BOOST": {
+      "checksum": "d8daf6968682343c79aa423f9c8db613d83460a51121a4f4b8a1f8e6e233af76",
+      "guess": "BSL-1.0",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/ryu",
+    "ltype": "Apache-2.0 OR BSL-1.0",
+    "attribution": [],
+    "children": [
+     "ryu"
+    ]
+   },
+   "rust::safemem": {
+    "name": "safemem",
+    "path": ".mole.rust_cache/kcserver/safemem-0.3.3",
+    "version": "0.3.3",
+    "author": "Austin Bonander <austin.bonander@gmail.com>",
+    "attribution": [
+     "Copyright 2016 The `multipart` Crate Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/safemem-0.3.3/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/safemem-0.3.3/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 The `multipart` Crate Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/abonander/safemem",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "safemem"
+    ]
+   },
+   "rust::schannel": {
+    "name": "schannel",
+    "path": ".mole.rust_cache/kcserver/schannel-0.1.23",
+    "version": "0.1.23",
+    "author": "Steven Fackler <sfackler@gmail.com>, Steffen Butzer <steffen.butzer@outlook.com>",
+    "attribution": [
+     "Copyright 2015 steffengy"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/schannel-0.1.23/LICENSE.md": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 steffengy"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/steffengy/schannel-rs",
+    "ltype": "MIT",
+    "children": [
+     "schannel"
+    ]
+   },
+   "rust::scopeguard": {
+    "name": "scopeguard",
+    "path": ".mole.rust_cache/kcserver/scopeguard-1.2.0",
+    "version": "1.2.0",
+    "author": "bluss",
+    "attribution": [
+     "Copyright 2016-2019 Ulrik Sverdrup \"bluss\" and scopeguard developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/scopeguard-1.2.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/scopeguard-1.2.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016-2019 Ulrik Sverdrup \"bluss\" and scopeguard developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/bluss/scopeguard",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "scopeguard"
+    ]
+   },
+   "rust::rust-security-framework": {
+    "name": "rust-security-framework",
+    "path": ".mole.rust_cache/kcserver/security-framework-2.11.0",
+    "version": "2.11.0",
+    "author": "Steven Fackler <sfackler@gmail.com>, Kornel <kornel@geekhood.net>",
+    "attribution": [
+     "Copyright 2015 Steven Fackler"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/security-framework-2.11.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/security-framework-2.11.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Steven Fackler"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/kornelski/rust-security-framework",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "security-framework",
+     "security-framework-sys"
+    ]
+   },
+   "rust::serde": {
+    "name": "serde",
+    "path": ".mole.rust_cache/kcserver/serde-1.0.203",
+    "version": "1.0.203",
+    "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/serde-1.0.203/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/serde-1.0.203/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/serde-rs/serde",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "serde",
+     "serde_derive"
+    ]
+   },
+   "rust::serde_ignored": {
+    "name": "serde_ignored",
+    "path": ".mole.rust_cache/kcserver/serde_ignored-0.1.10",
+    "version": "0.1.10",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/serde_ignored-0.1.10/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/serde_ignored-0.1.10/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/serde-ignored",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "serde_ignored"
+    ]
+   },
+   "rust::serde_json": {
+    "name": "serde_json",
+    "path": ".mole.rust_cache/kcserver/serde_json-1.0.125",
+    "version": "1.0.125",
+    "author": "Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/serde_json-1.0.125/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/serde_json-1.0.125/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/serde-rs/json",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "serde_json"
+    ]
+   },
+   "rust::serde_with": {
+    "name": "serde_with",
+    "path": ".mole.rust_cache/kcserver/serde_with-3.11.0",
+    "version": "3.11.0",
+    "author": "Jonas Bushart, Marcin Ka\u017amierczak",
+    "attribution": [
+     "Copyright 2015 Jonas Bushart, Marcin Ka\u017amierczak"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/serde_with-3.11.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/serde_with-3.11.0/LICENSE-MIT": {
+      "checksum": "64378261248abaa02c2ffae190e8fe002205d7c85f0674220e5cd53f9b656366",
+      "attribution": [
+       "Copyright 2015 Jonas Bushart, Marcin Ka\u017amierczak"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/jonasbb/serde_with/",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "serde_with"
+    ]
+   },
+   "rust::serde_with_macros": {
+    "name": "serde_with_macros",
+    "path": ".mole.rust_cache/kcserver/serde_with_macros-3.11.0",
+    "version": "3.11.0",
+    "author": "Jonas Bushart",
+    "attribution": [
+     "Copyright 2015 Jonas Bushart"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/serde_with_macros-3.11.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/serde_with_macros-3.11.0/LICENSE-MIT": {
+      "checksum": "64378261248abaa02c2ffae190e8fe002205d7c85f0674220e5cd53f9b656366",
+      "attribution": [
+       "Copyright 2015 Jonas Bushart"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/jonasbb/serde_with/",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "serde_with_macros"
+    ]
+   },
+   "rust::hashes": {
+    "name": "hashes",
+    "path": ".mole.rust_cache/kcserver/sha1-0.10.6",
+    "version": "0.10.6",
+    "author": "RustCrypto Developers",
+    "attribution": [
+     "Copyright 2006-2009 Graydon Hoare",
+     "Copyright 2009-2013 Mozilla Foundation",
+     "Copyright 2016 Artyom Pavlov"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/sha1-0.10.6/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/sha1-0.10.6/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2006-2009 Graydon Hoare",
+       "Copyright 2009-2013 Mozilla Foundation",
+       "Copyright 2016 Artyom Pavlov"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/RustCrypto/hashes",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "sha1",
+     "sha2"
+    ]
+   },
+   "rust::shlex": {
+    "name": "shlex",
+    "path": ".mole.rust_cache/kcserver/shlex-1.3.0",
+    "version": "1.3.0",
+    "author": "comex <comexk@gmail.com>, Fenhl <fenhl@fenhl.net>, Adrian Taylor <adetaylor@chromium.org>, Alex Touchet <alextouchet@outlook.com>, Daniel Parks <dp+git@oxidized.org>, Garrett Berg <googberg@gmail.com>",
+    "attribution": [
+     "Copyright 2015 Nicholas Allegra (comex)."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/shlex-1.3.0/LICENSE-APACHE": {
+      "checksum": "5e2bb1e6b78861a8b13150f493003aedab4168a1f338b8d4cea4763255a99ece",
+      "attribution": [
+       "Copyright 2015 Nicholas Allegra (comex)."
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/shlex-1.3.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Nicholas Allegra (comex)."
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/comex/rust-shlex",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "shlex"
+    ]
+   },
+   "rust::signal-hook-registry": {
+    "name": "signal-hook-registry",
+    "path": ".mole.rust_cache/kcserver/signal-hook-registry-1.4.2",
+    "version": "1.4.2",
+    "author": "Michal 'vorner' Vaner <vorner@vorner.cz>, Masaki Hara <ackie.h.gmai@gmail.com>",
+    "attribution": [
+     "Copyright 2017 tokio-jsonrpc developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/signal-hook-registry-1.4.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/signal-hook-registry-1.4.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 tokio-jsonrpc developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/vorner/signal-hook",
+    "ltype": "Apache-2.0/MIT",
+    "children": [
+     "signal-hook-registry"
+    ]
+   },
+   "rust::simple_asn1": {
+    "name": "simple_asn1",
+    "path": ".mole.rust_cache/kcserver/simple_asn1-0.6.3",
+    "version": "0.6.3",
+    "author": "Adam Wick <awick@uhsure.com>",
+    "attribution": [
+     "Copyright 2017 Adam Wick"
+    ],
+    "licenses": [
+     "ISC"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/simple_asn1-0.6.3/LICENSE": {
+      "checksum": "1e18580d06358dabfd3c9a852c611e3d1b0f272ea0fc17b4cd3bff86ef62c7a9",
+      "attribution": [
+       "Copyright 2017 Adam Wick"
+      ]
+     }
+    },
+    "repo": "https://github.com/acw/simple_asn1",
+    "ltype": "ISC",
+    "children": [
+     "simple_asn1"
+    ]
+   },
+   "rust::simple_logger": {
+    "name": "simple_logger",
+    "path": ".mole.rust_cache/kcserver/simple_logger-2.3.0",
+    "version": "2.3.0",
+    "author": "Sam Clements <sam@borntyping.co.uk>",
+    "attribution": [
+     "Copyright 2015-2021 Sam Clements"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/simple_logger-2.3.0/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015-2021 Sam Clements"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/borntyping/rust-simple_logger",
+    "ltype": "MIT",
+    "children": [
+     "simple_logger"
+    ]
+   },
+   "rust::simplelog": {
+    "name": "simplelog",
+    "path": ".mole.rust_cache/kcserver/simplelog-0.12.2",
+    "version": "0.12.2",
+    "author": "Drakulix <github@drakulix.de>",
+    "attribution": [
+     "Copyright 2015 Victor Brekenfeld"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/simplelog-0.12.2/LICENSE.APACHE2": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/simplelog-0.12.2/LICENSE.MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Victor Brekenfeld"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/drakulix/simplelog.rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "simplelog"
+    ]
+   },
+   "rust::slab": {
+    "name": "slab",
+    "path": ".mole.rust_cache/kcserver/slab-0.4.9",
+    "version": "0.4.9",
+    "author": "Carl Lerche <me@carllerche.com>",
+    "attribution": [
+     "Copyright 2019 Carl Lerche"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/slab-0.4.9/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 Carl Lerche"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tokio-rs/slab",
+    "ltype": "MIT",
+    "children": [
+     "slab"
+    ]
+   },
+   "rust::slog": {
+    "name": "slog",
+    "path": ".mole.rust_cache/kcserver/slog-2.7.0",
+    "version": "2.7.0",
+    "author": "Dawid Ci\u0119\u017carkiewicz <dpc@dpc.pw>",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT",
+     "MPL-2.0"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/slog-2.7.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/slog-2.7.0/LICENSE-MPL2": {
+      "checksum": "6220c16f40d2d10bdb2eff01e42c666b171ec2fe6940f2eb3f7e8d95f49c9531",
+      "guess": "MPL-2.0"
+     },
+     ".mole.rust_cache/kcserver/slog-2.7.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/slog-rs/slog",
+    "ltype": "MPL-2.0 OR MIT OR Apache-2.0",
+    "children": [
+     "slog"
+    ]
+   },
+   "rust::smallvec": {
+    "name": "smallvec",
+    "path": ".mole.rust_cache/kcserver/smallvec-1.13.2",
+    "version": "1.13.2",
+    "author": "The Servo Project Developers",
+    "attribution": [
+     "Copyright 2018 The Servo Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/smallvec-1.13.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/smallvec-1.13.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 The Servo Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/servo/rust-smallvec",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "smallvec"
+    ]
+   },
+   "rust::socket2": {
+    "name": "socket2",
+    "path": ".mole.rust_cache/kcserver/socket2-0.5.7",
+    "version": "0.5.7",
+    "author": "Alex Crichton <alex@alexcrichton.com>, Thomas de Zeeuw <thomasdezeeuw@gmail.com>",
+    "attribution": [
+     "Copyright 2014 Alex Crichton"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/socket2-0.5.7/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/socket2-0.5.7/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 Alex Crichton"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rust-lang/socket2",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "socket2"
+    ]
+   },
+   "rust::strsim": {
+    "name": "strsim",
+    "path": ".mole.rust_cache/kcserver/strsim-0.11.1",
+    "version": "0.11.1",
+    "author": "Danny Guo <danny@dannyguo.com>, maxbachmann <oss@maxbachmann.de>",
+    "attribution": [
+     "Copyright 2015 Danny Guo",
+     "Copyright 2016 Titus Wormer <tituswormer@gmail.com>",
+     "Copyright 2018 Akash Kurdekar"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/strsim-0.11.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Danny Guo",
+       "Copyright 2016 Titus Wormer <tituswormer@gmail.com>",
+       "Copyright 2018 Akash Kurdekar"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/rapidfuzz/strsim-rs",
+    "ltype": "MIT",
+    "children": [
+     "strsim"
+    ]
+   },
+   "rust::structopt": {
+    "name": "structopt",
+    "path": ".mole.rust_cache/kcserver/structopt-0.3.26",
+    "version": "0.3.26",
+    "author": "Guillaume Pinot <texitoi@texitoi.eu>, others",
+    "attribution": [
+     "Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/structopt-0.3.26/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/structopt-0.3.26/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/TeXitoi/structopt",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "structopt"
+    ]
+   },
+   "rust::structopt-derive": {
+    "name": "structopt-derive",
+    "path": ".mole.rust_cache/kcserver/structopt-derive-0.4.18",
+    "version": "0.4.18",
+    "author": "Guillaume Pinot <texitoi@texitoi.eu>",
+    "attribution": [
+     "Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/structopt-derive-0.4.18/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/structopt-derive-0.4.18/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/TeXitoi/structopt",
+    "ltype": "Apache-2.0/MIT",
+    "children": [
+     "structopt-derive"
+    ]
+   },
+   "rust::subtle": {
+    "name": "subtle",
+    "path": ".mole.rust_cache/kcserver/subtle-2.6.1",
+    "version": "2.6.1",
+    "author": "Isis Lovecruft <isis@patternsinthevoid.net>, Henry de Valence <hdevalence@hdevalence.ca>",
+    "attribution": [
+     "Copyright 2016-2017 Isis Agora Lovecruft, Henry de Valence.",
+     "Copyright 2016-2024 Isis Agora Lovecruft."
+    ],
+    "licenses": [
+     "BSD-3-Clause"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/subtle-2.6.1/LICENSE": {
+      "checksum": "2fb682f8f75bb738d3d17617a0d06047c916e50eeec172524c988169a6b3aa4e",
+      "attribution": [
+       "Copyright 2016-2017 Isis Agora Lovecruft, Henry de Valence.",
+       "Copyright 2016-2024 Isis Agora Lovecruft."
+      ],
+      "guess": "BSD-3-Clause"
+     }
+    },
+    "repo": "https://github.com/dalek-cryptography/subtle",
+    "ltype": "BSD-3-Clause",
+    "children": [
+     "subtle"
+    ]
+   },
+   "rust::swagger": {
+    "name": "swagger",
+    "path": ".mole.rust_cache/kcserver/swagger-6.5.0",
+    "version": "6.5.0",
+    "author": "Metaswitch Networks Ltd",
+    "attribution": [
+     "Copyright 2017 libraries.core"
+    ],
+    "licenses": [
+     "Apache-2.0"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/swagger-6.5.0/LICENSE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2017 libraries.core"
+      ],
+      "guess": "Apache-2.0"
+     }
+    },
+    "repo": "https://github.com/Metaswitch/swagger-rs",
+    "ltype": "Apache-2.0",
+    "children": [
+     "swagger"
+    ]
+   },
+   "rust::syn": {
+    "name": "syn",
+    "path": ".mole.rust_cache/kcserver/syn-2.0.101",
+    "version": "2.0.101",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/syn-2.0.101/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/syn-2.0.101/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/syn",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "syn"
+    ]
+   },
+   "rust::sysinfo": {
+    "name": "sysinfo",
+    "path": ".mole.rust_cache/kcserver/sysinfo-0.31.4",
+    "version": "0.31.4",
+    "author": "Guillaume Gomez <guillaume1.gomez@gmail.com>",
+    "attribution": [
+     "Copyright 2015 Guillaume Gomez"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/sysinfo-0.31.4/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Guillaume Gomez"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/GuillaumeGomez/sysinfo",
+    "ltype": "MIT",
+    "children": [
+     "sysinfo"
+    ]
+   },
+   "rust::tempfile": {
+    "name": "tempfile",
+    "path": ".mole.rust_cache/kcserver/tempfile-3.10.1",
+    "version": "3.10.1",
+    "author": "Steven Allen <steven@stebalien.com>, The Rust Project Developers, Ashley Mannix <ashleymannix@live.com.au>, Jason White <me@jasonwhite.io>",
+    "attribution": [
+     "Copyright 2015 Steven Allen"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tempfile-3.10.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/tempfile-3.10.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Steven Allen"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/Stebalien/tempfile",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "tempfile"
+    ]
+   },
+   "rust::termcolor": {
+    "name": "termcolor",
+    "path": ".mole.rust_cache/kcserver/termcolor-1.4.1",
+    "version": "1.4.1",
+    "author": "Andrew Gallant <jamslam@gmail.com>",
+    "attribution": [
+     "Copyright 2015 Andrew Gallant"
+    ],
+    "licenses": [
+     "MIT",
+     "Unlicense"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/termcolor-1.4.1/COPYING": {
+      "checksum": "18cb1e425a6d45a4e98b6fc3b4d85f85d333862fe906555b2168e8234fefe111",
+      "guess": "MIT",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/termcolor-1.4.1/UNLICENSE": {
+      "checksum": "daa475343600cbb7ef14411d59b1eea77fb8f66c48dcc8cb6cceb9cdbe0c07a9",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/termcolor-1.4.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 Andrew Gallant"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/BurntSushi/termcolor",
+    "ltype": "Unlicense OR MIT",
+    "children": [
+     "termcolor"
+    ]
+   },
+   "rust::terminal_size": {
+    "name": "terminal_size",
+    "path": ".mole.rust_cache/kcserver/terminal_size-0.1.17",
+    "version": "0.1.17",
+    "author": "Andrew Chin <achin@eminence32.net>",
+    "attribution": [
+     "Copyright 2015 The terminal-size Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/terminal_size-0.1.17/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/terminal_size-0.1.17/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The terminal-size Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/eminence/terminal-size",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "terminal_size"
+    ]
+   },
+   "rust::textwrap": {
+    "name": "textwrap",
+    "path": ".mole.rust_cache/kcserver/textwrap-0.11.0",
+    "version": "0.11.0",
+    "author": "Martin Geisler <martin@geisler.net>",
+    "attribution": [
+     "Copyright 2016 Martin Geisler"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/textwrap-0.11.0/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Martin Geisler"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/mgeisler/textwrap",
+    "ltype": "MIT",
+    "children": [
+     "textwrap"
+    ]
+   },
+   "rust::thiserror": {
+    "name": "thiserror",
+    "path": ".mole.rust_cache/kcserver/thiserror-2.0.12",
+    "version": "2.0.12",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/thiserror-2.0.12/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/thiserror-2.0.12/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/thiserror",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "thiserror",
+     "thiserror-impl"
+    ]
+   },
+   "rust::time": {
+    "name": "time",
+    "path": ".mole.rust_cache/kcserver/time-0.3.36",
+    "version": "0.3.36",
+    "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
+    "attribution": [
+     "Copyright 2024 Jacob Pratt et al."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/time-0.3.36/LICENSE-Apache": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2024 Jacob Pratt et al."
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/time-0.3.36/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2024 Jacob Pratt et al."
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/time-rs/time",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "time",
+     "time-macros"
+    ]
+   },
+   "rust::time-core": {
+    "name": "time-core",
+    "path": ".mole.rust_cache/kcserver/time-core-0.1.2",
+    "version": "0.1.2",
+    "author": "Jacob Pratt <open-source@jhpratt.dev>, Time contributors",
+    "attribution": [
+     "Copyright 2022 Jacob Pratt et al."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/time-core-0.1.2/LICENSE-Apache": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2022 Jacob Pratt et al."
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/time-core-0.1.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2022 Jacob Pratt et al."
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/time-rs/time",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "time-core"
+    ]
+   },
+   "rust::tinyvec": {
+    "name": "tinyvec",
+    "path": ".mole.rust_cache/kcserver/tinyvec-1.6.0",
+    "version": "1.6.0",
+    "author": "Lokathor <zefria@gmail.com>",
+    "attribution": [
+     "Copyright 2019 Daniel \"Lokathor\" Gee."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT",
+     "Zlib"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tinyvec-1.6.0/LICENSE-MIT.md": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/tinyvec-1.6.0/LICENSE-ZLIB.md": {
+      "checksum": "d1a157d7f695f1e9a3b2db78e734ba809eebae72b109db34d64a90c91759d568",
+      "attribution": [
+       "Copyright 2019 Daniel \"Lokathor\" Gee."
+      ]
+     },
+     ".mole.rust_cache/kcserver/tinyvec-1.6.0/LICENSE-APACHE.md": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/Lokathor/tinyvec",
+    "ltype": "Zlib OR Apache-2.0 OR MIT",
+    "children": [
+     "tinyvec"
+    ]
+   },
+   "rust::tinyvec_macros": {
+    "name": "tinyvec_macros",
+    "path": ".mole.rust_cache/kcserver/tinyvec_macros-0.1.1",
+    "version": "0.1.1",
+    "author": "Soveu <marx.tomasz@gmail.com>",
+    "attribution": [
+     "Copyright (C) 2020 Tomasz \"Soveu\" Marx",
+     "Copyright 2020 Soveu",
+     "Copyright 2020 Tomasz \"Soveu\" Marx"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT",
+     "Zlib"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tinyvec_macros-0.1.1/LICENSE-MIT.md": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2020 Soveu"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     },
+     ".mole.rust_cache/kcserver/tinyvec_macros-0.1.1/LICENSE-ZLIB.md": {
+      "checksum": "2e47b2636655db22bbef637e2ebdd55ea1fe4d261c47ca435a4bdea8a5fa310f",
+      "attribution": [
+       "Copyright (C) 2020 Tomasz \"Soveu\" Marx"
+      ]
+     },
+     ".mole.rust_cache/kcserver/tinyvec_macros-0.1.1/LICENSE-APACHE.md": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2020 Tomasz \"Soveu\" Marx"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     }
+    },
+    "repo": "https://github.com/Soveu/tinyvec_macros",
+    "ltype": "MIT OR Apache-2.0 OR Zlib",
+    "children": [
+     "tinyvec_macros"
+    ]
+   },
+   "rust::tokio": {
+    "name": "tokio",
+    "path": ".mole.rust_cache/kallichore_api/tokio-test-0.4.4",
+    "version": "0.4.4",
+    "author": "Tokio Contributors <team@tokio.rs>",
+    "attribution": [
+     "Copyright 2023 Tokio Contributors"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kallichore_api/tokio-test-0.4.4/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2023 Tokio Contributors"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tokio-rs/tokio",
+    "ltype": "MIT",
+    "children": [
+     "tokio-test",
+     "tokio-util",
+     "tokio",
+     "tokio-stream"
+    ]
+   },
+   "rust::tokio-macros": {
+    "name": "tokio-macros",
+    "path": ".mole.rust_cache/kcserver/tokio-macros-2.3.0",
+    "version": "2.3.0",
+    "author": "Tokio Contributors <team@tokio.rs>",
+    "attribution": [
+     "Copyright 2019 Yoshua Wuyts",
+     "Copyright Tokio Contributors"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tokio-macros-2.3.0/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 Yoshua Wuyts",
+       "Copyright Tokio Contributors"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tokio-rs/tokio",
+    "ltype": "MIT",
+    "children": [
+     "tokio-macros"
+    ]
+   },
+   "rust::tokio-openssl": {
+    "name": "tokio-openssl",
+    "path": ".mole.rust_cache/kcserver/tokio-openssl-0.6.4",
+    "version": "0.6.4",
+    "author": "Alex Crichton <alex@alexcrichton.com>",
+    "attribution": [
+     "Copyright 2016 Tokio contributors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tokio-openssl-0.6.4/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2016 Tokio contributors"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/tokio-openssl-0.6.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Tokio contributors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tokio-rs/tokio-openssl",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "tokio-openssl"
+    ]
+   },
+   "rust::tokio-tungstenite": {
+    "name": "tokio-tungstenite",
+    "path": ".mole.rust_cache/kcserver/tokio-tungstenite-0.23.1",
+    "version": "0.23.1",
+    "author": "Daniel Abramov <dabramov@snapview.de>, Alexey Galakhov <agalakhov@snapview.de>",
+    "attribution": [
+     "Copyright 2017 Alexey Galakhov",
+     "Copyright 2017 Daniel Abramov"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tokio-tungstenite-0.23.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Alexey Galakhov",
+       "Copyright 2017 Daniel Abramov"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/snapview/tokio-tungstenite",
+    "ltype": "MIT",
+    "children": [
+     "tokio-tungstenite"
+    ]
+   },
+   "rust::tower-service": {
+    "name": "tower-service",
+    "path": ".mole.rust_cache/kcserver/tower-service-0.3.2",
+    "version": "0.3.2",
+    "author": "Tower Maintainers <team@tower-rs.com>",
+    "attribution": [
+     "Copyright 2019 Tower Contributors"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tower-service-0.3.2/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 Tower Contributors"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tower-rs/tower",
+    "ltype": "MIT",
+    "children": [
+     "tower-service"
+    ]
+   },
+   "rust::tracing": {
+    "name": "tracing",
+    "path": ".mole.rust_cache/kcserver/tracing-0.1.40",
+    "version": "0.1.40",
+    "author": "Eliza Weisman <eliza@buoyant.io>, Tokio Contributors <team@tokio.rs>",
+    "attribution": [
+     "Copyright 2019 Tokio Contributors"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tracing-0.1.40/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2019 Tokio Contributors"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/tokio-rs/tracing",
+    "ltype": "MIT",
+    "children": [
+     "tracing",
+     "tracing-core"
+    ]
+   },
+   "rust::try-lock": {
+    "name": "try-lock",
+    "path": ".mole.rust_cache/kcserver/try-lock-0.2.5",
+    "version": "0.2.5",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2016 Alex Crichton",
+     "Copyright 2018-2023 Sean McArthur"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/try-lock-0.2.5/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Alex Crichton",
+       "Copyright 2018-2023 Sean McArthur"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/seanmonstar/try-lock",
+    "ltype": "MIT",
+    "children": [
+     "try-lock"
+    ]
+   },
+   "rust::tungstenite": {
+    "name": "tungstenite",
+    "path": ".mole.rust_cache/kcserver/tungstenite-0.23.0",
+    "version": "0.23.0",
+    "author": "Alexey Galakhov, Daniel Abramov",
+    "attribution": [
+     "Copyright 2016 Jason Housley",
+     "Copyright 2017 Alexey Galakhov"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/tungstenite-0.23.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/tungstenite-0.23.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Jason Housley",
+       "Copyright 2017 Alexey Galakhov"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/snapview/tungstenite-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "tungstenite"
+    ]
+   },
+   "rust::typenum": {
+    "name": "typenum",
+    "path": ".mole.rust_cache/kcserver/typenum-1.17.0",
+    "version": "1.17.0",
+    "author": "Paho Lurie-Gregg <paho@paholg.com>, Andre Bogus <bogusandre@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "repo": "https://github.com/paholg/typenum",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [
+     "Copyright 2014 Paho Lurie-Gregg"
+    ],
+    "children": [
+     "typenum"
+    ]
+   },
+   "rust::unicase": {
+    "name": "unicase",
+    "path": ".mole.rust_cache/kcserver/unicase-2.7.0",
+    "version": "2.7.0",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2014-2017 Sean McArthur"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/unicase-2.7.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicase-2.7.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014-2017 Sean McArthur"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/seanmonstar/unicase",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "unicase"
+    ]
+   },
+   "rust::unicode-bidi": {
+    "name": "unicode-bidi",
+    "path": ".mole.rust_cache/kcserver/unicode-bidi-0.3.15",
+    "version": "0.3.15",
+    "author": "The Servo Project Developers",
+    "attribution": [
+     "Copyright 2015 The Rust Project Developers",
+     "This project is copyright 2015, The Servo Project Developers (given in the file AUTHORS)."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/unicode-bidi-0.3.15/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicode-bidi-0.3.15/COPYRIGHT": {
+      "checksum": "0355e3d5c06110f233cace36ca64b1f08e8e918b3d9da4a0656d25b72a946c7b",
+      "attribution": [
+       "This project is copyright 2015, The Servo Project Developers (given in the file AUTHORS)."
+      ],
+      "multi": true
+     },
+     ".mole.rust_cache/kcserver/unicode-bidi-0.3.15/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/servo/unicode-bidi",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "unicode-bidi"
+    ]
+   },
+   "rust::unicode-ident": {
+    "name": "unicode-ident",
+    "path": ".mole.rust_cache/kcserver/unicode-ident-1.0.12",
+    "version": "1.0.12",
+    "author": "David Tolnay <dtolnay@gmail.com>",
+    "attribution": [
+     "Copyright \u00a9 1991-2022 Unicode, Inc."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT",
+     "Unicode-DFS-2016"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/unicode-ident-1.0.12/LICENSE-UNICODE": {
+      "checksum": "1ac751de86bbe0e97ba414cbe37def04755fdbddd07735d165326c82184bf5d2",
+      "attribution": [
+       "Copyright \u00a9 1991-2022 Unicode, Inc."
+      ]
+     },
+     ".mole.rust_cache/kcserver/unicode-ident-1.0.12/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicode-ident-1.0.12/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/dtolnay/unicode-ident",
+    "ltype": "(MIT OR Apache-2.0) AND Unicode-DFS-2016",
+    "children": [
+     "unicode-ident"
+    ]
+   },
+   "rust::unicode-normalization": {
+    "name": "unicode-normalization",
+    "path": ".mole.rust_cache/kcserver/unicode-normalization-0.1.23",
+    "version": "0.1.23",
+    "author": "kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+    "attribution": [
+     "Copyright 2015 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/unicode-normalization-0.1.23/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicode-normalization-0.1.23/COPYRIGHT": {
+      "checksum": "0355e3d5c06110f233cace36ca64b1f08e8e918b3d9da4a0656d25b72a946c7b",
+      "multi": true,
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicode-normalization-0.1.23/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/unicode-rs/unicode-normalization",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "unicode-normalization"
+    ]
+   },
+   "rust::unicode-segmentation": {
+    "name": "unicode-segmentation",
+    "path": ".mole.rust_cache/kcserver/unicode-segmentation-1.12.0",
+    "version": "1.12.0",
+    "author": "kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+    "attribution": [
+     "Copyright 2015 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/unicode-segmentation-1.12.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicode-segmentation-1.12.0/COPYRIGHT": {
+      "checksum": "0355e3d5c06110f233cace36ca64b1f08e8e918b3d9da4a0656d25b72a946c7b",
+      "multi": true,
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicode-segmentation-1.12.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/unicode-rs/unicode-segmentation",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "unicode-segmentation"
+    ]
+   },
+   "rust::unicode-width": {
+    "name": "unicode-width",
+    "path": ".mole.rust_cache/kcserver/unicode-width-0.1.13",
+    "version": "0.1.13",
+    "author": "kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>",
+    "attribution": [
+     "Copyright 2015 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/unicode-width-0.1.13/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicode-width-0.1.13/COPYRIGHT": {
+      "checksum": "0355e3d5c06110f233cace36ca64b1f08e8e918b3d9da4a0656d25b72a946c7b",
+      "multi": true,
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/unicode-width-0.1.13/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/unicode-rs/unicode-width",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "unicode-width"
+    ]
+   },
+   "rust::untrusted": {
+    "name": "untrusted",
+    "path": ".mole.rust_cache/kcserver/untrusted-0.9.0",
+    "version": "0.9.0",
+    "author": "Brian Smith <brian@briansmith.org>",
+    "attribution": [
+     "Copyright 2015-2016 Brian Smith."
+    ],
+    "licenses": [
+     "ISC"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/untrusted-0.9.0/LICENSE.txt": {
+      "checksum": "8d24b70f510dce3780c38ed7d1a037e38942a5f71e619c0a4cd8383f2ed01fd9",
+      "attribution": [
+       "Copyright 2015-2016 Brian Smith."
+      ]
+     }
+    },
+    "repo": "https://github.com/briansmith/untrusted",
+    "ltype": "ISC",
+    "children": [
+     "untrusted"
+    ]
+   },
+   "rust::url": {
+    "name": "url",
+    "path": ".mole.rust_cache/kcserver/url-2.5.2",
+    "version": "2.5.2",
+    "author": "The rust-url developers",
+    "attribution": [
+     "Copyright 2013-2022 The rust-url developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/url-2.5.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/url-2.5.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2013-2022 The rust-url developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/servo/rust-url",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "url"
+    ]
+   },
+   "rust::urlencoding": {
+    "name": "urlencoding",
+    "path": ".mole.rust_cache/kcserver/urlencoding-2.1.3",
+    "version": "2.1.3",
+    "author": "Kornel <kornel@geekhood.net>, Bertram Truong <b@bertramtruong.com>",
+    "attribution": [
+     "Copyright \u00a9 2016 Bertram Truong \u00a9 2021 Kornel Lesi\u0144ski"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/urlencoding-2.1.3/LICENSE": {
+      "checksum": "1a8d04bffe853c6dcdfc7dfab29e08b9c55a5855fe7575c124aa86ac08bf0566",
+      "attribution": [
+       "Copyright \u00a9 2016 Bertram Truong \u00a9 2021 Kornel Lesi\u0144ski"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/kornelski/rust_urlencoding",
+    "ltype": "MIT",
+    "children": [
+     "urlencoding"
+    ]
+   },
+   "rust::utf-8": {
+    "name": "utf-8",
+    "path": ".mole.rust_cache/kcserver/utf-8-0.7.6",
+    "version": "0.7.6",
+    "author": "Simon Sapin <simon.sapin@exyr.org>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/utf-8-0.7.6/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/utf-8-0.7.6/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/SimonSapin/rust-utf8",
+    "ltype": "MIT OR Apache-2.0",
+    "attribution": [],
+    "children": [
+     "utf-8"
+    ]
+   },
+   "rust::utf8parse": {
+    "name": "utf8parse",
+    "path": ".mole.rust_cache/kcserver/utf8parse-0.2.2",
+    "version": "0.2.2",
+    "author": "Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>",
+    "attribution": [
+     "Copyright 2016 Joe Wilm"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/utf8parse-0.2.2/LICENSE-APACHE": {
+      "checksum": "68e8ffaa3caefb980d3486b3e8ab44568f7afc148981e938f1a19e562675ed71",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/utf8parse-0.2.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2016 Joe Wilm"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/alacritty/vte",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "utf8parse"
+    ]
+   },
+   "rust::uuid": {
+    "name": "uuid",
+    "path": ".mole.rust_cache/kcserver/uuid-1.10.0",
+    "version": "1.10.0",
+    "author": "Ashley Mannix<ashleymannix@live.com.au>, Dylan DPC<dylan.dpc@gmail.com>, Hunar Roop Kahlon<hunar.roop@gmail.com>",
+    "attribution": [
+     "Copyright 2014 The Rust Project Developers",
+     "Copyright 2018 Ashley Mannix, Christopher Armstrong, Dylan DPC, Hunar Roop Kahlon"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/uuid-1.10.0/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/uuid-1.10.0/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2014 The Rust Project Developers",
+       "Copyright 2018 Ashley Mannix, Christopher Armstrong, Dylan DPC, Hunar Roop Kahlon"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/uuid-rs/uuid",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "uuid"
+    ]
+   },
+   "rust::validator": {
+    "name": "validator",
+    "path": ".mole.rust_cache/kcserver/validator-0.16.1",
+    "version": "0.16.1",
+    "author": "Vincent Prouillet <hello@vincentprouillet.com",
+    "licenses": [
+     "MIT"
+    ],
+    "repo": "https://github.com/Keats/validator",
+    "ltype": "MIT",
+    "attribution": [],
+    "children": [
+     "validator",
+     "validator_derive",
+     "validator_types"
+    ]
+   },
+   "rust::vcpkg": {
+    "name": "vcpkg",
+    "path": ".mole.rust_cache/kcserver/vcpkg-0.2.15",
+    "version": "0.2.15",
+    "author": "Jim McGrath <jimmc2@gmail.com>",
+    "attribution": [
+     "Copyright 2017 Jim McGrath"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/vcpkg-0.2.15/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/vcpkg-0.2.15/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Jim McGrath"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/mcgoo/vcpkg-rs",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "vcpkg"
+    ]
+   },
+   "rust::vec_map": {
+    "name": "vec_map",
+    "path": ".mole.rust_cache/kcserver/vec_map-0.8.2",
+    "version": "0.8.2",
+    "author": "Alex Crichton <alex@alexcrichton.com>, Jorge Aparicio <japaricious@gmail.com>, Alexis Beingessner <a.beingessner@gmail.com>, Brian Anderson <>, tbu- <>, Manish Goregaokar <>, Aaron Turon <aturon@mozilla.com>, Adolfo Ochagav\u00eda <>, Niko Matsakis <>, Steven Fackler <>, Chase Southwood <csouth3@illinois.edu>, Eduard Burtescu <>, Florian Wilkens <>, F\u00e9lix Raimundo <>, Tibor Benke <>, Markus Siemens <markus@m-siemens.de>, Josh Branchaud <jbranchaud@gmail.com>, Huon Wilson <dbau.pp@gmail.com>, Corey Farwell <coref@rwell.org>, Aaron Liblong <>, Nick Cameron <nrc@ncameron.org>, Patrick Walton <pcwalton@mimiga.net>, Felix S Klock II <>, Andrew Paseltiner <apaseltiner@gmail.com>, Sean McArthur <sean.monstar@gmail.com>, Vadim Petrochenkov <>",
+    "attribution": [
+     "Copyright 2015 The Rust Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/vec_map-0.8.2/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/vec_map-0.8.2/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015 The Rust Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/contain-rs/vec-map",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "vec_map"
+    ]
+   },
+   "rust::version_check": {
+    "name": "version_check",
+    "path": ".mole.rust_cache/kcserver/version_check-0.9.4",
+    "version": "0.9.4",
+    "author": "Sergio Benitez <sb@sergio.bz>",
+    "attribution": [
+     "Copyright 2017-2018 Sergio Benitez"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/version_check-0.9.4/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/version_check-0.9.4/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017-2018 Sergio Benitez"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/SergioBenitez/version_check",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "version_check"
+    ]
+   },
+   "rust::want": {
+    "name": "want",
+    "path": ".mole.rust_cache/kcserver/want-0.3.1",
+    "version": "0.3.1",
+    "author": "Sean McArthur <sean@seanmonstar.com>",
+    "attribution": [
+     "Copyright 2018-2019 Sean McArthur"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/want-0.3.1/LICENSE": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018-2019 Sean McArthur"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/seanmonstar/want",
+    "ltype": "MIT",
+    "children": [
+     "want"
+    ]
+   },
+   "rust::wasi": {
+    "name": "wasi",
+    "path": ".mole.rust_cache/kcserver/wasi-0.11.0+wasi-snapshot-preview1",
+    "version": "0.11.0+wasi-snapshot-preview1",
+    "author": "The Cranelift Project Developers",
+    "licenses": [
+     "Apache-2.0",
+     "Apache-2.0 WITH LLVM-exception",
+     "Apache-2.0-WITH-LLVM-Exceptions",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/wasi-0.11.0+wasi-snapshot-preview1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/wasi-0.11.0+wasi-snapshot-preview1/LICENSE-Apache-2.0_WITH_LLVM-exception": {
+      "checksum": "ae5b2e89f93f2cd35ca2cce86976b63eb6f7c4b52999aa096fe2d29ee59f86bc",
+      "spdx": [
+       "Apache-2.0-WITH-LLVM-Exceptions"
+      ],
+      "guess": "Apache-2.0-WITH-LLVM-Exceptions",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/wasi-0.11.0+wasi-snapshot-preview1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT",
+      "clean": true
+     }
+    },
+    "repo": "https://github.com/bytecodealliance/wasi",
+    "ltype": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+    "attribution": [],
+    "children": [
+     "wasi"
+    ]
+   },
+   "rust::winapi": {
+    "name": "winapi",
+    "path": ".mole.rust_cache/kcserver/winapi-0.3.9",
+    "version": "0.3.9",
+    "author": "Peter Atashian <retep998@gmail.com>",
+    "attribution": [
+     "Copyright 2015-2018 The winapi-rs Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/winapi-0.3.9/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/winapi-0.3.9/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2015-2018 The winapi-rs Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/retep998/winapi-rs",
+    "ltype": "MIT/Apache-2.0",
+    "children": [
+     "winapi"
+    ]
+   },
+   "rust::winapi-rs": {
+    "name": "winapi-rs",
+    "path": ".mole.rust_cache/kcserver/winapi-i686-pc-windows-gnu-0.4.0",
+    "version": "0.4.0",
+    "author": "Peter Atashian <retep998@gmail.com>",
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "repo": "https://github.com/retep998/winapi-rs",
+    "ltype": "MIT/Apache-2.0",
+    "attribution": [],
+    "children": [
+     "winapi-i686-pc-windows-gnu",
+     "winapi-x86_64-pc-windows-gnu"
+    ]
+   },
+   "rust::winapi-util": {
+    "name": "winapi-util",
+    "path": ".mole.rust_cache/kcserver/winapi-util-0.1.8",
+    "version": "0.1.8",
+    "author": "Andrew Gallant <jamslam@gmail.com>",
+    "attribution": [
+     "Copyright 2017 Andrew Gallant"
+    ],
+    "licenses": [
+     "MIT",
+     "Unlicense"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/winapi-util-0.1.8/COPYING": {
+      "checksum": "18cb1e425a6d45a4e98b6fc3b4d85f85d333862fe906555b2168e8234fefe111",
+      "guess": "MIT",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/winapi-util-0.1.8/UNLICENSE": {
+      "checksum": "daa475343600cbb7ef14411d59b1eea77fb8f66c48dcc8cb6cceb9cdbe0c07a9",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/winapi-util-0.1.8/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2017 Andrew Gallant"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/BurntSushi/winapi-util",
+    "ltype": "Unlicense OR MIT",
+    "children": [
+     "winapi-util"
+    ]
+   },
+   "rust::windows-rs": {
+    "name": "windows-rs",
+    "path": ".mole.rust_cache/kcserver/windows-0.58.0",
+    "version": "0.58.0",
+    "author": "Microsoft",
+    "attribution": [
+     "Copyright Microsoft Corporation."
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/windows-0.58.0/license-apache-2.0": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright Microsoft Corporation."
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/windows-0.58.0/license-mit": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright Microsoft Corporation."
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/microsoft/windows-rs",
+    "ltype": "MIT OR Apache-2.0",
+    "children": [
+     "windows",
+     "windows-core",
+     "windows-implement",
+     "windows-interface",
+     "windows-result",
+     "windows-strings",
+     "windows-sys",
+     "windows-targets",
+     "windows_aarch64_gnullvm",
+     "windows_aarch64_msvc",
+     "windows_i686_gnu",
+     "windows_i686_gnullvm",
+     "windows_i686_msvc",
+     "windows_x86_64_gnu",
+     "windows_x86_64_gnullvm",
+     "windows_x86_64_msvc"
+    ]
+   },
+   "rust::zerocopy": {
+    "name": "zerocopy",
+    "path": ".mole.rust_cache/kcserver/zerocopy-0.7.35",
+    "version": "0.7.35",
+    "author": "Joshua Liebow-Feeser <joshlf@google.com>",
+    "attribution": [
+     "Copyright 2019 The Fuchsia Authors.",
+     "Copyright 2023 The Fuchsia Authors"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "BSD-2-Clause",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/zerocopy-0.7.35/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "attribution": [
+       "Copyright 2023 The Fuchsia Authors"
+      ],
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0"
+     },
+     ".mole.rust_cache/kcserver/zerocopy-0.7.35/LICENSE-BSD": {
+      "checksum": "9d48361350b694571ee07e060a740515b10b9737773e8bd01de8b4db72907eae",
+      "attribution": [
+       "Copyright 2019 The Fuchsia Authors."
+      ]
+     },
+     ".mole.rust_cache/kcserver/zerocopy-0.7.35/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2023 The Fuchsia Authors"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/google/zerocopy",
+    "ltype": "BSD-2-Clause OR Apache-2.0 OR MIT",
+    "children": [
+     "zerocopy",
+     "zerocopy-derive"
+    ]
+   },
+   "rust::zeroize": {
+    "name": "zeroize",
+    "path": ".mole.rust_cache/kcserver/zeroize-1.8.1",
+    "version": "1.8.1",
+    "author": "The RustCrypto Project Developers",
+    "attribution": [
+     "Copyright 2018-2021 The RustCrypto Project Developers"
+    ],
+    "licenses": [
+     "Apache-2.0",
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/zeroize-1.8.1/LICENSE-APACHE": {
+      "checksum": "435a02bc8ff881291e04a4e556955bc4b771affd2dd3de4487109fcbc4c4cb55",
+      "spdx": [
+       "Apache-2.0"
+      ],
+      "guess": "Apache-2.0",
+      "clean": true
+     },
+     ".mole.rust_cache/kcserver/zeroize-1.8.1/LICENSE-MIT": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2018-2021 The RustCrypto Project Developers"
+      ],
+      "spdx": [
+       "MIT"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/RustCrypto/utils",
+    "ltype": "Apache-2.0 OR MIT",
+    "children": [
+     "zeroize"
+    ]
+   },
+   "rust::zeromq": {
+    "name": "zeromq",
+    "path": ".mole.rust_cache/kcserver/zeromq-0.4.1",
+    "version": "0.4.1",
+    "author": "Alexei Kornienko <alexei.kornienko@gmail.com>",
+    "attribution": [
+     "Copyright 2020 Alexei Kornienko"
+    ],
+    "licenses": [
+     "MIT"
+    ],
+    "license_files": {
+     ".mole.rust_cache/kcserver/zeromq-0.4.1/LICENSE.md": {
+      "checksum": "6015fc144718ef9dea4cd0d05629677785992d6812f1e66ce1b7abde07d0f531",
+      "attribution": [
+       "Copyright 2020 Alexei Kornienko"
+      ],
+      "guess": "MIT"
+     }
+    },
+    "repo": "https://github.com/zeromq/zmq.rs",
+    "ltype": "MIT",
+    "children": [
+     "zeromq"
+    ]
+   },
+   "!root": [
+    "KALLICHORE_PATH",
+    "crates/kcshared",
+    "crates/kcserver",
+    "crates/kcclient",
+    "crates/kallichore_api"
+   ]
+  }
+ }
+}

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12462 @@
+Licenses
+========
+
+Kallichore includes and/or derives from other open source software
+components. This document lists those components, where to find the source
+code for these components, and the full text of their license statements.
+
+You may also request a copy of the source code for any of these components
+by sending an email to info@posit.co
+
+Components used by Kallichore
+===========================
+* addr2line (Apache, MIT licenses)
+* adler (0BSD, Apache, MIT licenses)
+* aho-corasick (MIT, Unlicense licenses)
+* android-tzdata (Apache, MIT licenses)
+* android_system_properties (Apache, MIT licenses)
+* ansi_term (MIT license)
+* anstream (Apache, MIT licenses)
+* anstyle (Apache, MIT licenses)
+* anstyle-parse (Apache, MIT licenses)
+* anstyle-query (Apache, MIT licenses)
+* anstyle-wincon (Apache, MIT licenses)
+* anyhow (Apache, MIT licenses)
+* async-channel (Apache, MIT licenses)
+* async-stream (MIT license)
+* async-trait (Apache, MIT licenses)
+* asynchronous-codec (MIT license)
+* atty (MIT license)
+* autocfg (Apache, MIT licenses)
+* backtrace (Apache, MIT licenses)
+* base64 (Apache, MIT licenses)
+* bitflags (Apache, MIT licenses)
+* block-buffer (Apache, MIT licenses)
+* bumpalo (Apache, MIT licenses)
+* byteorder (MIT, Unlicense licenses)
+* bytes (MIT license)
+* cc (Apache, MIT licenses)
+* cfg-if (Apache, MIT licenses)
+* chrono (Apache, MIT licenses)
+* clap (Apache, MIT licenses)
+* clap-verbosity-flag (Apache, MIT licenses)
+* colorchoice (Apache, MIT licenses)
+* colored (MPLv2 license)
+* concurrent-queue (Apache, MIT licenses)
+* console (MIT license)
+* core-foundation-rs (Apache, MIT licenses)
+* cpufeatures (Apache, MIT licenses)
+* crossbeam (Apache, MIT licenses)
+* crypto-common (Apache, MIT licenses)
+* darling (MIT license)
+* dashmap (MIT license)
+* data-encoding (MIT license)
+* deranged (Apache, MIT licenses)
+* dialoguer (MIT license)
+* digest (Apache, MIT licenses)
+* directories (Apache, MIT licenses)
+* dirs-sys (Apache, MIT licenses)
+* either (Apache, MIT licenses)
+* encode_unicode (Apache, MIT licenses)
+* env_logger (Apache, MIT licenses)
+* equivalent (Apache, MIT licenses)
+* errno (Apache, MIT licenses)
+* event-listener (Apache, MIT licenses)
+* event-listener-strategy (Apache, MIT licenses)
+* fastrand (Apache, MIT licenses)
+* fnv (Apache, MIT licenses)
+* foreign-types (Apache, MIT licenses)
+* form_urlencoded (Apache, MIT licenses)
+* frunk (MIT license)
+* frunk-enum (Apache, MIT licenses)
+* futures-rs (Apache, MIT licenses)
+* generic-array (MIT license)
+* getrandom (Apache, MIT licenses)
+* gimli (Apache, MIT licenses)
+* h2 (MIT license)
+* hashbrown (Apache, MIT licenses)
+* hashes (Apache, MIT licenses)
+* heck (Apache, MIT licenses)
+* hermit-abi (Apache, MIT licenses)
+* hex (Apache, MIT licenses)
+* hmac (Apache, MIT licenses)
+* http (Apache, MIT licenses)
+* http-body (MIT license)
+* httparse (Apache, MIT licenses)
+* httpdate (Apache, MIT licenses)
+* humantime (Apache, MIT licenses)
+* hyper (MIT license)
+* hyper-old-types (MIT license)
+* hyper-util (MIT license)
+* hyperlocal (MIT license)
+* iana-time-zone (Apache, MIT licenses)
+* ident_case (Apache, MIT licenses)
+* if_chain (Apache, MIT licenses)
+* indexmap (Apache, MIT licenses)
+* iovec (Apache, MIT licenses)
+* is_terminal_polyfill (Apache, MIT licenses)
+* itertools (Apache, MIT licenses)
+* itoa (Apache, MIT licenses)
+* jsonwebtoken (MIT license)
+* language-tags (MIT license)
+* lazy_static (Apache, MIT licenses)
+* libc (Apache, MIT licenses)
+* libredox (MIT license)
+* linux-raw-sys (Apache, MIT licenses)
+* log (Apache, MIT licenses)
+* memchr (MIT, Unlicense licenses)
+* mime (Apache, MIT licenses)
+* miniz_oxide (Apache, MIT, zlib licenses)
+* mio (MIT license)
+* native-tls (Apache, MIT licenses)
+* ntapi (Apache, MIT licenses)
+* num-bigint (Apache, MIT licenses)
+* num-conv (Apache, MIT licenses)
+* num-integer (Apache, MIT licenses)
+* num-traits (Apache, MIT licenses)
+* num_cpus (Apache, MIT licenses)
+* num_threads (Apache, MIT licenses)
+* object (Apache, MIT licenses)
+* once_cell (Apache, MIT licenses)
+* openssl (Apache license)
+* openssl-macros (Apache, MIT licenses)
+* openssl-probe (Apache, MIT licenses)
+* openssl-sys (MIT license)
+* option-ext (MPLv2 license)
+* parking (Apache, MIT licenses)
+* parking_lot (Apache, MIT licenses)
+* pem (MIT license)
+* pin-project (Apache, MIT licenses)
+* pin-project-lite (Apache, MIT licenses)
+* pin-utils (Apache, MIT licenses)
+* pkg-config (Apache, MIT licenses)
+* powerfmt (Apache, MIT licenses)
+* ppv-lite86 (Apache, MIT licenses)
+* proc-macro-error (Apache, MIT licenses)
+* proc-macro2 (Apache, MIT licenses)
+* quote (Apache, MIT licenses)
+* rand (Apache, MIT licenses)
+* rayon (Apache, MIT licenses)
+* redox_syscall (MIT license)
+* redox_users (MIT license)
+* regex (Apache, MIT licenses)
+* ring (Apache, BoringSSL, ISC, MIT licenses)
+* Rust standard libraries (Apache, MIT licenses)
+* rust-security-framework (Apache, MIT licenses)
+* rust-url (Apache, MIT licenses)
+* rustc-demangle (Apache, MIT licenses)
+* rustix (Apache, MIT licenses)
+* ryu (Apache, Boost licenses)
+* safemem (Apache, MIT licenses)
+* schannel (MIT license)
+* scopeguard (Apache, MIT licenses)
+* serde (Apache, MIT licenses)
+* serde_ignored (Apache, MIT licenses)
+* serde_json (Apache, MIT licenses)
+* serde_with (Apache, MIT licenses)
+* serde_with_macros (Apache, MIT licenses)
+* shlex (Apache, MIT licenses)
+* signal-hook-registry (Apache, MIT licenses)
+* simplelog (Apache, MIT licenses)
+* simple_asn1 (ISC license)
+* simple_logger (MIT license)
+* slab (MIT license)
+* slog (Apache, MIT, MPLv2 licenses)
+* smallvec (Apache, MIT licenses)
+* socket2 (Apache, MIT licenses)
+* strsim (MIT license)
+* structopt (Apache, MIT licenses)
+* structopt-derive (Apache, MIT licenses)
+* subtle (BSD license)
+* swagger (Apache license)
+* syn (Apache, MIT licenses)
+* sysinfo (MIT license)
+* tempfile (Apache, MIT licenses)
+* termcolor (MIT, Unlicense licenses)
+* terminal_size (Apache, MIT licenses)
+* textwrap (MIT license)
+* thiserror (Apache, MIT licenses)
+* time (Apache, MIT licenses)
+* time-core (Apache, MIT licenses)
+* tinyvec (Apache, MIT, zlib licenses)
+* tinyvec_macros (Apache, MIT, zlib licenses)
+* tokio (MIT license)
+* tokio-macros (MIT license)
+* tokio-openssl (Apache, MIT licenses)
+* tokio-tungstenite (MIT license)
+* tower-service (MIT license)
+* tracing (MIT license)
+* try-lock (MIT license)
+* tungstenite (Apache, MIT licenses)
+* typenum (Apache, MIT licenses)
+* unicase (Apache, MIT licenses)
+* unicode-bidi (Apache, MIT licenses)
+* unicode-ident (Apache, MIT, Unicode-DFS licenses)
+* unicode-normalization (Apache, MIT licenses)
+* unicode-segmentation (Apache, MIT licenses)
+* unicode-width (Apache, MIT licenses)
+* untrusted (ISC license)
+* url (Apache, MIT licenses)
+* urlencoding (MIT license)
+* utf-8 (Apache, MIT licenses)
+* utf8parse (Apache, MIT licenses)
+* uuid (Apache, MIT licenses)
+* validator (MIT license)
+* vcpkg (Apache, MIT licenses)
+* vec_map (Apache, MIT licenses)
+* version_check (Apache, MIT licenses)
+* want (MIT license)
+* wasi (Apache, MIT licenses)
+* wasm-bindgen (Apache, MIT licenses)
+* winapi (Apache, MIT licenses)
+* winapi-rs (Apache, MIT licenses)
+* winapi-util (MIT, Unlicense licenses)
+* windows-rs (Apache, MIT licenses)
+* zerocopy (Apache, BSD, MIT licenses)
+* zeroize (Apache, MIT licenses)
+* zeromq (MIT license)
+
+Licenses used by multiple components
+====================================
+
+Apache License version 2.0
+--------------------------
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Apache License version 2.0 with LLVM Exceptions
+-----------------------------------------------
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+MIT License
+-----------
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+Unlicense
+---------
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+
+Component-specific licenses
+===========================
+
+addr2line
+---------
+Website: https://github.com/gimli-rs/addr2line
+
+Copyright 2016-2018 The gimli Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of addr2line for more information.
+
+MIT License text:
+
+Copyright (c) 2016-2018 The gimli Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+adler
+-----
+Website: https://github.com/jonas-schievink/adler
+
+Copyright (C) Jonas Schievink <jonasschievink@gmail.com>
+
+Distributed under multiple software licenses, including:
+    0BSD License
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of adler for more information.
+
+0BSD License text:
+
+Copyright (C) Jonas Schievink <jonasschievink@gmail.com>
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+aho-corasick
+------------
+Website: https://github.com/BurntSushi/aho-corasick
+
+Copyright 2015 Andrew Gallant
+
+Distributed under multiple software licenses, including:
+    MIT License
+    Unlicense
+Consult the documentation and source code of aho-corasick for more information.
+
+
+android-tzdata
+--------------
+Website: https://github.com/RumovZ/android-tzdata
+
+Copyright [year] [fullname]
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of android-tzdata for more information.
+
+MIT License text:
+
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+android_system_properties
+-------------------------
+Website: https://github.com/nical/android_system_properties
+
+Copyright 2016 Nicolas Silva
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of android_system_properties for more information.
+
+Apache License version 2.0 text:
+
+Copyright 2016 Nicolas Silva
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Nicolas Silva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+ansi_term
+---------
+Website: https://github.com/ogham/rust-ansi-term
+
+Copyright 2014 Benjamin Sago
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Benjamin Sago
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+anstream
+--------
+Website: https://github.com/rust-cli/anstyle
+
+Copyright Individual contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of anstream for more information.
+
+MIT License text:
+
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+anstyle
+-------
+Website: https://github.com/rust-cli/anstyle
+
+Copyright 2022 The rust-cli Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of anstyle for more information.
+
+MIT License text:
+
+Copyright (c) 2022 The rust-cli Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+anstyle-parse
+-------------
+Website: https://github.com/rust-cli/anstyle
+
+Copyright 2016 Joe Wilm and individual contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of anstyle-parse for more information.
+
+MIT License text:
+
+Copyright (c) 2016 Joe Wilm and individual contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+anstyle-query
+-------------
+Website: https://github.com/rust-cli/anstyle
+
+Copyright Individual contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of anstyle-query for more information.
+
+MIT License text:
+
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+anstyle-wincon
+--------------
+Website: https://github.com/rust-cli/anstyle
+
+Copyright 2015 Josh Triplett, 2022 The rust-cli Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of anstyle-wincon for more information.
+
+MIT License text:
+
+Copyright (c) 2015 Josh Triplett, 2022 The rust-cli Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+anyhow
+------
+Website: https://github.com/dtolnay/anyhow
+
+Published by David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of anyhow for more information.
+
+
+async-channel
+-------------
+Website: https://github.com/smol-rs/async-channel
+
+Published by Stjepan Glavina <stjepang@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of async-channel for more information.
+
+
+async-stream
+------------
+Website: https://github.com/tokio-rs/async-stream
+
+Copyright 2018 David Tolnay
+Copyright 2019 Carl Lerche
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2019 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+Copyright (c) 2018 David Tolnay
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+async-trait
+-----------
+Website: https://github.com/dtolnay/async-trait
+
+Published by David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of async-trait for more information.
+
+
+asynchronous-codec
+------------------
+Website: https://github.com/mxinden/asynchronous-codec
+
+Copyright 2019 - 2020 Matt Hunzinger
+Copyright 2021 Max Inden
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2019 - 2020 Matt Hunzinger
+
+Copyright (c) 2021 Max Inden
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+atty
+----
+Website: https://github.com/softprops/atty
+
+Copyright 2015-2019 Doug Tangren
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2015-2019 Doug Tangren
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+autocfg
+-------
+Website: https://github.com/cuviper/autocfg
+
+Copyright 2018 Josh Stone
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of autocfg for more information.
+
+MIT License text:
+
+Copyright (c) 2018 Josh Stone
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+backtrace
+---------
+Website: https://github.com/rust-lang/backtrace-rs
+
+Copyright 2014 Alex Crichton
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of backtrace for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+base64
+------
+Website: https://github.com/marshallpierce/rust-base64
+
+Copyright 2015 Alice Maz
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of base64 for more information.
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Alice Maz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+bitflags
+--------
+Website: https://github.com/bitflags/bitflags
+
+Copyright 2014 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of bitflags for more information.
+
+MIT License text:
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+block-buffer
+------------
+Website: https://github.com/RustCrypto/utils
+
+Copyright 2018-2019 The RustCrypto Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of block-buffer for more information.
+
+MIT License text:
+
+Copyright (c) 2018-2019 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+bumpalo
+-------
+Website: https://github.com/fitzgen/bumpalo
+
+Copyright 2019 Nick Fitzgerald
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of bumpalo for more information.
+
+MIT License text:
+
+Copyright (c) 2019 Nick Fitzgerald
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+byteorder
+---------
+Website: https://github.com/BurntSushi/byteorder
+
+Copyright 2015 Andrew Gallant
+
+Distributed under multiple software licenses, including:
+    MIT License
+    Unlicense
+Consult the documentation and source code of byteorder for more information.
+
+
+bytes
+-----
+Website: https://github.com/tokio-rs/bytes
+
+Copyright 2018 Carl Lerche
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2018 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+cc
+--
+Website: https://github.com/rust-lang/cc-rs
+
+Copyright 2014 Alex Crichton
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of cc for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+cfg-if
+------
+Website: https://github.com/alexcrichton/cfg-if
+
+Copyright 2014 Alex Crichton
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of cfg-if for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+chrono
+------
+Website: https://github.com/chronotope/chrono
+
+Copyright 2014, Kang Seonghoon.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of chrono for more information.
+
+License text (Apache License version 2.0, MIT License):
+
+Rust-chrono is dual-licensed under The MIT License [1] and
+Apache 2.0 License [2]. Copyright (c) 2014--2017, Kang Seonghoon and
+contributors.
+
+Nota Bene: This is same as the Rust Project's own license.
+
+[1]: <http://opensource.org/licenses/MIT>, which is reproduced below:
+
+~~~~
+
+The MIT License (MIT)
+
+Copyright (c) 2014, Kang Seonghoon.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+~~~~
+
+[2]: <http://www.apache.org/licenses/LICENSE-2.0>, which is reproduced below:
+
+~~~~
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+~~~~
+
+
+clap
+----
+Website: https://github.com/clap-rs/clap
+
+Copyright 2015-2022 Kevin B. Knapp and Clap Contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of clap for more information.
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2022 Kevin B. Knapp and Clap Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+clap-verbosity-flag
+-------------------
+Website: https://github.com/rust-clique/clap-verbosity-flag
+
+Copyright 2018 The clap-verbosity-flag Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of clap-verbosity-flag for more information.
+
+MIT License text:
+
+Copyright (c) 2018 The clap-verbosity-flag Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+colorchoice
+-----------
+Website: https://github.com/rust-cli/anstyle
+
+Copyright Individual contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of colorchoice for more information.
+
+MIT License text:
+
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+colored
+-------
+Website: https://github.com/mackwic/colored
+
+Published by Thomas Wickham <mackwic@gmail.com>
+Distributed under the Mozilla Public License version 2.0
+
+Mozilla Public License version 2.0 text:
+
+Mozilla Public License Version 2.0
+
+==================================
+
+1. Definitions
+
+   --------------
+
+1.1. "Contributor"
+
+means each individual or legal entity that creates, contributes to
+the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+means the combination of the Contributions of others (if any) used
+by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+means Source Code Form to which the initial Contributor has attached
+the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+means
+
+a) that the initial Contributor has attached the notice described
+    in Exhibit B to the Covered Software; or
+
+b) that the Covered Software was made available under the terms of
+    version 1.1 or earlier of the License, but not also under the
+    terms of a Secondary License.
+
+1.6. "Executable Form"
+
+means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+means a work that combines Covered Software with other material, in
+a separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+means this document.
+
+1.9. "Licensable"
+
+means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
+
+1.10. "Modifications"
+
+means any of the following:
+
+a) any file in Source Code Form that results from an addition to,
+    deletion from, or modification of the contents of Covered
+    Software; or
+
+b) any new file in Source Code Form that contains any Covered
+    Software.
+
+1.11. "Patent Claims" of a Contributor
+
+means any patent claim(s), including without limitation, method,
+process, and apparatus claims, in any patent Licensable by such
+Contributor that would be infringed, but for the grant of the
+License, by the making, using, selling, offering for sale, having
+made, import, or transfer of either its Contributions or its
+Contributor Version.
+
+1.12. "Secondary License"
+
+means either the GNU General Public License, Version 2.0, the GNU
+Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those
+licenses.
+
+1.13. "Source Code Form"
+
+means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+means an individual or a legal entity exercising rights under this
+License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For
+purposes of this definition, "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of more than
+fifty percent (50%) of the outstanding shares or beneficial
+ownership of such entity.
+
+2. License Grants and Conditions
+
+   --------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+a) for any code that a Contributor has removed from Covered Software;
+    or
+
+b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+    This License does not grant any rights in the trademarks, service marks,
+    or logos of any Contributor (except as may be necessary to comply with
+    the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+
+   -------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+   ---------------------------------------------------
+
+   If it is impossible for You to comply with any of the terms of this
+   License with respect to some or all of the Covered Software due to
+   statute, judicial order, or regulation then You must: (a) comply with
+   the terms of this License to the maximum extent possible; and (b)
+   describe the limitations and the code they affect. Such description must
+   be placed in a text file included with all distributions of the Covered
+   Software under this License. Except to the extent prohibited by statute
+   or regulation, such description must be sufficiently detailed for a
+   recipient of ordinary skill to be able to understand it.
+
+5. Termination
+
+   --------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+**6. Disclaimer of Warranty**
+
+**-------------------------**
+
+**Covered Software is provided under this License on an "as is"**
+**basis, without warranty of any kind, either expressed, implied, or**
+**statutory, including, without limitation, warranties that the**
+**Covered Software is free of defects, merchantable, fit for a**
+**particular purpose or non-infringing. The entire risk as to the**
+**quality and performance of the Covered Software is with You.**
+**Should any Covered Software prove defective in any respect, You**
+**(not any Contributor) assume the cost of any necessary servicing,**
+**repair, or correction. This disclaimer of warranty constitutes an**
+**essential part of this License. No use of any Covered Software is**
+**authorized under this License except under this disclaimer.**
+
+**7. Limitation of Liability**
+
+**--------------------------**
+
+**Under no circumstances and under no legal theory, whether tort**
+**(including negligence), contract, or otherwise, shall any**
+**Contributor, or anyone who distributes Covered Software as**
+**permitted above, be liable to You for any direct, indirect,**
+**special, incidental, or consequential damages of any character**
+**including, without limitation, damages for lost profits, loss of**
+**goodwill, work stoppage, computer failure or malfunction, or any**
+**and all other commercial damages or losses, even if such party**
+**shall have been informed of the possibility of such damages. This**
+**limitation of liability shall not apply to liability for death or**
+**personal injury resulting from such party's negligence to the**
+**extent applicable law prohibits such limitation. Some**
+**jurisdictions do not allow the exclusion or limitation of**
+**incidental or consequential damages, so this exclusion and**
+**limitation may not apply to You.**
+
+8. Litigation
+
+   -------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   ----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.
+
+
+concurrent-queue
+----------------
+Website: https://github.com/smol-rs/concurrent-queue
+
+Published by Stjepan Glavina <stjepang@gmail.com>, Taiki Endo <te316e89@gmail.com>, John Nunley <dev@notgull.net>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of concurrent-queue for more information.
+
+
+console
+-------
+Website: https://github.com/mitsuhiko/console
+
+Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Armin Ronacher <armin.ronacher@active-4.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+core-foundation-rs
+------------------
+Website: https://github.com/servo/core-foundation-rs
+
+Copyright 2012-2013 Mozilla Foundation
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of core-foundation-rs for more information.
+
+MIT License text:
+
+Copyright (c) 2012-2013 Mozilla Foundation
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+cpufeatures
+-----------
+Website: https://github.com/RustCrypto/utils
+
+Copyright 2020 The RustCrypto Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of cpufeatures for more information.
+
+MIT License text:
+
+Copyright (c) 2020 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+crossbeam
+---------
+Website: https://github.com/crossbeam-rs/crossbeam
+
+Copyright 2019 The Crossbeam Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of crossbeam for more information.
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2019 The Crossbeam Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+crypto-common
+-------------
+Website: https://github.com/RustCrypto/traits
+
+Copyright 2021 RustCrypto Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of crypto-common for more information.
+
+MIT License text:
+
+Copyright (c) 2021 RustCrypto Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+darling
+-------
+Website: https://github.com/TedDriggs/darling
+
+Copyright 2017 Ted Driggs
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2017 Ted Driggs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+dashmap
+-------
+Website: https://github.com/xacrimon/dashmap
+
+Copyright 2019 Acrimon
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2019 Acrimon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+data-encoding
+-------------
+Website: https://github.com/ia0/data-encoding
+
+Copyright 2015-2020 Julien Cretin
+Copyright 2017-2020 Google Inc.
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2020 Julien Cretin
+
+Copyright (c) 2017-2020 Google Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+deranged
+--------
+Website: https://github.com/jhpratt/deranged
+
+Copyright 2022 Jacob Pratt et al.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of deranged for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2022 Jacob Pratt et al.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2022 Jacob Pratt et al.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+dialoguer
+---------
+Website: https://github.com/mitsuhiko/dialoguer
+
+Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Armin Ronacher <armin.ronacher@active-4.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+digest
+------
+Website: https://github.com/RustCrypto/traits
+
+Copyright 2017 Artyom Pavlov
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of digest for more information.
+
+MIT License text:
+
+Copyright (c) 2017 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+directories
+-----------
+Website: https://github.com/soc/directories-rs
+
+Copyright 2018 directories-rs contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of directories for more information.
+
+MIT License text:
+
+Copyright (c) 2018 directories-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+dirs-sys
+--------
+Website: https://github.com/dirs-dev/dirs-sys-rs
+
+Copyright 2018-2019 dirs-rs contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of dirs-sys for more information.
+
+MIT License text:
+
+Copyright (c) 2018-2019 dirs-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+either
+------
+Website: https://github.com/rayon-rs/either
+
+Copyright 2015 bluss
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of either for more information.
+
+MIT License text:
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+encode_unicode
+--------------
+Website: https://github.com/tormol/encode_unicode
+
+Published by Torbjørn Birch Moltu <t.b.moltu@lyse.net>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of encode_unicode for more information.
+
+
+env_logger
+----------
+Website: https://github.com/rust-cli/env_logger
+
+Copyright Individual contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of env_logger for more information.
+
+MIT License text:
+
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+equivalent
+----------
+Website: https://github.com/cuviper/equivalent
+
+Copyright 2016--2023
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of equivalent for more information.
+
+MIT License text:
+
+Copyright (c) 2016--2023
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+errno
+-----
+Website: https://github.com/lambda-fairy/rust-errno
+
+Copyright 2014 Chris Wong
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of errno for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Chris Wong
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+event-listener
+--------------
+Website: https://github.com/smol-rs/event-listener
+
+Published by Stjepan Glavina <stjepang@gmail.com>, John Nunley <dev@notgull.net>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of event-listener for more information.
+
+
+event-listener-strategy
+-----------------------
+Website: https://github.com/smol-rs/event-listener-strategy
+
+Published by John Nunley <dev@notgull.net>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of event-listener-strategy for more information.
+
+
+fastrand
+--------
+Website: https://github.com/smol-rs/fastrand
+
+Published by Stjepan Glavina <stjepang@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of fastrand for more information.
+
+
+fnv
+---
+Website: https://github.com/servo/rust-fnv
+
+Copyright 2017 Contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of fnv for more information.
+
+MIT License text:
+
+Copyright (c) 2017 Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+foreign-types
+-------------
+Website: https://github.com/sfackler/foreign-types
+
+Copyright 2017 The foreign-types Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of foreign-types for more information.
+
+MIT License text:
+
+Copyright (c) 2017 The foreign-types Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+form_urlencoded
+---------------
+Website: https://github.com/servo/rust-url
+
+Copyright 2013-2016 The rust-url developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of form_urlencoded for more information.
+
+MIT License text:
+
+Copyright (c) 2013-2016 The rust-url developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+frunk
+-----
+Website: https://github.com/lloydmeta/frunk
+
+Published by Lloyd <lloydmeta@gmail.com>
+Distributed under the MIT License
+
+
+frunk-enum
+----------
+Website: https://github.com/Metaswitch/frunk-enum
+
+Copyright 2018 Metaswitch Networks
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of frunk-enum for more information.
+
+Apache License version 2.0 text:
+
+Copyright 2018 Metaswitch Networks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright 2018 Metaswitch Networks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+futures-rs
+----------
+Website: https://github.com/rust-lang/futures-rs
+
+Copyright 2016 Alex Crichton
+Copyright 2017 The Tokio Authors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of futures-rs for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright (c) 2016 Alex Crichton
+
+Copyright (c) 2017 The Tokio Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2016 Alex Crichton
+
+Copyright (c) 2017 The Tokio Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+generic-array
+-------------
+Website: https://github.com/fizyk20/generic-array
+
+Copyright 2015 Bartłomiej Kamiński
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Bartłomiej Kamiński
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+getrandom
+---------
+Website: https://github.com/rust-random/getrandom
+
+Copyright 2014 The Rust Project Developers
+Copyright 2018-2024 The rust-random Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of getrandom for more information.
+
+MIT License text:
+
+Copyright (c) 2018-2024 The rust-random Project Developers
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+gimli
+-----
+Website: https://github.com/gimli-rs/gimli
+
+Copyright 2015 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of gimli for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+h2
+--
+Website: https://github.com/hyperium/h2
+
+Copyright 2017 h2 authors
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2017 h2 authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+hashbrown
+---------
+Website: https://github.com/rust-lang/hashbrown
+
+Copyright 2016 Amanieu d'Antras
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of hashbrown for more information.
+
+MIT License text:
+
+Copyright (c) 2016 Amanieu d'Antras
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+hashes
+------
+Website: https://github.com/RustCrypto/hashes
+
+Copyright 2006-2009 Graydon Hoare
+Copyright 2009-2013 Mozilla Foundation
+Copyright 2016 Artyom Pavlov
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of hashes for more information.
+
+MIT License text:
+
+Copyright (c) 2006-2009 Graydon Hoare
+
+Copyright (c) 2009-2013 Mozilla Foundation
+
+Copyright (c) 2016 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+heck
+----
+Website: https://github.com/withoutboats/heck
+
+Copyright 2015 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of heck for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+hermit-abi
+----------
+Website: https://github.com/hermit-os/hermit-rs
+
+Published by Stefan Lankes
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of hermit-abi for more information.
+
+
+hex
+---
+Website: https://github.com/KokaKiwi/rust-hex
+
+Copyright 2013-2014 The Rust Project Developers.
+Copyright 2015-2020 The rust-hex Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of hex for more information.
+
+MIT License text:
+
+Copyright (c) 2013-2014 The Rust Project Developers.
+
+Copyright (c) 2015-2020 The rust-hex Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+hmac
+----
+Website: https://github.com/RustCrypto/MACs
+
+Copyright 2017 Artyom Pavlov
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of hmac for more information.
+
+MIT License text:
+
+Copyright (c) 2017 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+http
+----
+Website: https://github.com/hyperium/http
+
+Copyright 2017 http-rs authors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of http for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2017 http-rs authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2017 http-rs authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+http-body
+---------
+Website: https://github.com/hyperium/http-body
+
+Copyright 2019-2024 Sean McArthur & Hyper Contributors
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2019-2024 Sean McArthur & Hyper Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+httparse
+--------
+Website: https://github.com/seanmonstar/httparse
+
+Copyright 2015-2024 Sean McArthur
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of httparse for more information.
+
+MIT License text:
+
+Copyright (c) 2015-2024 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+httpdate
+--------
+Website: https://github.com/pyfisch/httpdate
+
+Copyright 2016 Pyfisch
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of httpdate for more information.
+
+MIT License text:
+
+Copyright (c) 2016 Pyfisch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+humantime
+---------
+Website: https://github.com/tailhook/humantime
+
+Copyright 2016 Pyfisch
+Copyright 2016 The humantime Developers
+Copyright © 2005-2013 Rich Felker
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of humantime for more information.
+
+MIT License text:
+
+Copyright (c) 2016 The humantime Developers
+
+Includes parts of http date with the following copyright:
+
+Copyright (c) 2016 Pyfisch
+
+Includes portions of musl libc with the following copyright:
+
+Copyright © 2005-2013 Rich Felker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+hyper
+-----
+Website: https://github.com/hyperium/hyper
+
+Copyright 2014-2021 Sean McArthur
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2014-2021 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+hyper-old-types
+---------------
+Website: https://github.com/hyperium/hyper-old-types
+
+Copyright 2014 Sean McArthur
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2014 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+hyper-util
+----------
+Website: https://github.com/hyperium/hyper-util
+
+Copyright 2023 Sean McArthur
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2023 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+hyperlocal
+----------
+Website: https://github.com/softprops/hyperlocal
+
+Copyright 2015-2020 Doug Tangren
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2015-2020 Doug Tangren
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+iana-time-zone
+--------------
+Website: https://github.com/strawlab/iana-time-zone
+
+Copyright 2020 Andrew D. Straw
+Copyright 2020 Andrew Straw
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of iana-time-zone for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2020 Andrew Straw
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2020 Andrew D. Straw
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+ident_case
+----------
+Website: https://github.com/TedDriggs/ident_case
+
+Published by Ted Driggs <ted.driggs@outlook.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of ident_case for more information.
+
+
+if_chain
+--------
+Website: https://github.com/lambda-fairy/if_chain
+
+Copyright 2018 Chris Wong
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of if_chain for more information.
+
+MIT License text:
+
+Copyright (c) 2018 Chris Wong
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+indexmap
+--------
+Website: https://github.com/indexmap-rs/indexmap
+
+Copyright 2016--2017
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of indexmap for more information.
+
+MIT License text:
+
+Copyright (c) 2016--2017
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+iovec
+-----
+Website: https://github.com/carllerche/iovec
+
+Copyright 2017 Carl Lerche
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of iovec for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2017 Carl Lerche
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2017 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+is_terminal_polyfill
+--------------------
+Website: https://github.com/polyfill-rs/is_terminal_polyfill
+
+Copyright Individual contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of is_terminal_polyfill for more information.
+
+MIT License text:
+
+Copyright (c) Individual contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+itertools
+---------
+Website: https://github.com/rust-itertools/itertools
+
+Copyright 2015 bluss
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of itertools for more information.
+
+MIT License text:
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+itoa
+----
+Website: https://github.com/dtolnay/itoa
+
+Published by David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of itoa for more information.
+
+
+jsonwebtoken
+------------
+Website: https://github.com/Keats/jsonwebtoken
+
+Copyright 2015 Vincent Prouillet
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Vincent Prouillet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+language-tags
+-------------
+Website: https://github.com/pyfisch/rust-language-tags
+
+Copyright 2015 Pyfisch
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2015 Pyfisch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+lazy_static
+-----------
+Website: https://github.com/rust-lang-nursery/lazy-static.rs
+
+Copyright 2010 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of lazy_static for more information.
+
+MIT License text:
+
+Copyright (c) 2010 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+libc
+----
+Website: https://github.com/rust-lang/libc
+
+Copyright 2014-2020 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of libc for more information.
+
+MIT License text:
+
+Copyright (c) 2014-2020 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+libredox
+--------
+Website: https://gitlab.redox-os.org/redox-os/libredox.git
+
+Copyright 2023 4lDO2
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2023 4lDO2
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+linux-raw-sys
+-------------
+Website: https://github.com/sunfishcode/linux-raw-sys
+
+Published by Dan Gohman <dev@sunfishcode.online>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0 with LLVM Exceptions
+    MIT License
+Consult the documentation and source code of linux-raw-sys for more information.
+
+
+log
+---
+Website: https://github.com/rust-lang/log
+
+Copyright 2014 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of log for more information.
+
+MIT License text:
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+memchr
+------
+Website: https://github.com/BurntSushi/memchr
+
+Copyright 2015 Andrew Gallant
+
+Distributed under multiple software licenses, including:
+    MIT License
+    Unlicense
+Consult the documentation and source code of memchr for more information.
+
+
+mime
+----
+Website: https://github.com/hyperium/mime
+
+Copyright 2014 Sean McArthur
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of mime for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+miniz_oxide
+-----------
+Website: https://github.com/Frommi/miniz_oxide
+
+Copyright 2020 Frommi
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+    zlib License
+Consult the documentation and source code of miniz_oxide for more information.
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2017 Frommi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+zlib License text:
+
+Copyright (c) 2020 Frommi
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+
+mio
+---
+Website: https://github.com/tokio-rs/mio
+
+Copyright 2014 Carl Lerche and other MIO contributors
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2014 Carl Lerche and other MIO contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+native-tls
+----------
+Website: https://github.com/sfackler/rust-native-tls
+
+Copyright 2016 The rust-native-tls Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of native-tls for more information.
+
+MIT License text:
+
+Copyright (c) 2016 The rust-native-tls Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+ntapi
+-----
+Website: https://github.com/MSxDOS/ntapi
+
+Published by MSxDOS <melcodos@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of ntapi for more information.
+
+
+num-bigint
+----------
+Website: https://github.com/rust-num/num-bigint
+
+Copyright 2014 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of num-bigint for more information.
+
+MIT License text:
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+num-conv
+--------
+Website: https://github.com/jhpratt/num-conv
+
+Copyright 2023 Jacob Pratt
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of num-conv for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2023 Jacob Pratt
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2023 Jacob Pratt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+num-integer
+-----------
+Website: https://github.com/rust-num/num-integer
+
+Copyright 2014 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of num-integer for more information.
+
+MIT License text:
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+num-traits
+----------
+Website: https://github.com/rust-num/num-traits
+
+Copyright 2014 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of num-traits for more information.
+
+MIT License text:
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+num_cpus
+--------
+Website: https://github.com/seanmonstar/num_cpus
+
+Copyright 2015 Sean McArthur <sean@seanmonstar.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of num_cpus for more information.
+
+MIT License text:
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+num_threads
+-----------
+Website: https://github.com/jhpratt/num_threads
+
+Copyright 2021 Jacob Pratt
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of num_threads for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2021 Jacob Pratt
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2021 Jacob Pratt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+object
+------
+Website: https://github.com/gimli-rs/object
+
+Copyright 2015 The Gimli Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of object for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The Gimli Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+once_cell
+---------
+Website: https://github.com/matklad/once_cell
+
+Published by Aleksey Kladov <aleksey.kladov@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of once_cell for more information.
+
+
+openssl
+-------
+Website: https://github.com/sfackler/rust-openssl
+
+Copyright 2011-2017 Google Inc. 2013 Jack Lloyd 2013-2014 Steven Fackler
+Distributed under the Apache License version 2.0
+
+Apache License version 2.0 text:
+
+Copyright 2011-2017 Google Inc.
+
+2013 Jack Lloyd
+
+2013-2014 Steven Fackler
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+openssl-macros
+--------------
+Website: (Could not find homepage for package)
+
+Copyright 2022 Steven Fackler
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of openssl-macros for more information.
+
+MIT License text:
+
+Copyright (c) 2022 Steven Fackler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+openssl-probe
+-------------
+Website: https://github.com/alexcrichton/openssl-probe
+
+Copyright 2014 Alex Crichton
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of openssl-probe for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+openssl-sys
+-----------
+Website: https://github.com/sfackler/rust-openssl
+
+Copyright 2014 Alex Crichton
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+option-ext
+----------
+Website: https://github.com/soc/option-ext
+
+Published by Simon Ochsenreither <simon@ochsenreither.de>
+Distributed under the Mozilla Public License version 2.0
+
+Mozilla Public License version 2.0 text:
+
+Mozilla Public License Version 2.0
+
+==================================
+
+1. Definitions
+
+   --------------
+
+1.1. "Contributor"
+
+means each individual or legal entity that creates, contributes to
+the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+means the combination of the Contributions of others (if any) used
+by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+means Source Code Form to which the initial Contributor has attached
+the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+means
+
+a) that the initial Contributor has attached the notice described
+    in Exhibit B to the Covered Software; or
+
+b) that the Covered Software was made available under the terms of
+    version 1.1 or earlier of the License, but not also under the
+    terms of a Secondary License.
+
+1.6. "Executable Form"
+
+means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+means a work that combines Covered Software with other material, in
+a separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+means this document.
+
+1.9. "Licensable"
+
+means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
+
+1.10. "Modifications"
+
+means any of the following:
+
+a) any file in Source Code Form that results from an addition to,
+    deletion from, or modification of the contents of Covered
+    Software; or
+
+b) any new file in Source Code Form that contains any Covered
+    Software.
+
+1.11. "Patent Claims" of a Contributor
+
+means any patent claim(s), including without limitation, method,
+process, and apparatus claims, in any patent Licensable by such
+Contributor that would be infringed, but for the grant of the
+License, by the making, using, selling, offering for sale, having
+made, import, or transfer of either its Contributions or its
+Contributor Version.
+
+1.12. "Secondary License"
+
+means either the GNU General Public License, Version 2.0, the GNU
+Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those
+licenses.
+
+1.13. "Source Code Form"
+
+means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+means an individual or a legal entity exercising rights under this
+License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For
+purposes of this definition, "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of more than
+fifty percent (50%) of the outstanding shares or beneficial
+ownership of such entity.
+
+2. License Grants and Conditions
+
+   --------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+a) for any code that a Contributor has removed from Covered Software;
+    or
+
+b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+    This License does not grant any rights in the trademarks, service marks,
+    or logos of any Contributor (except as may be necessary to comply with
+    the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+
+   -------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+   ---------------------------------------------------
+
+   If it is impossible for You to comply with any of the terms of this
+   License with respect to some or all of the Covered Software due to
+   statute, judicial order, or regulation then You must: (a) comply with
+   the terms of this License to the maximum extent possible; and (b)
+   describe the limitations and the code they affect. Such description must
+   be placed in a text file included with all distributions of the Covered
+   Software under this License. Except to the extent prohibited by statute
+   or regulation, such description must be sufficiently detailed for a
+   recipient of ordinary skill to be able to understand it.
+
+5. Termination
+
+   --------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+**6. Disclaimer of Warranty**
+
+**-------------------------**
+
+**Covered Software is provided under this License on an "as is"**
+**basis, without warranty of any kind, either expressed, implied, or**
+**statutory, including, without limitation, warranties that the**
+**Covered Software is free of defects, merchantable, fit for a**
+**particular purpose or non-infringing. The entire risk as to the**
+**quality and performance of the Covered Software is with You.**
+**Should any Covered Software prove defective in any respect, You**
+**(not any Contributor) assume the cost of any necessary servicing,**
+**repair, or correction. This disclaimer of warranty constitutes an**
+**essential part of this License. No use of any Covered Software is**
+**authorized under this License except under this disclaimer.**
+
+**7. Limitation of Liability**
+
+**--------------------------**
+
+**Under no circumstances and under no legal theory, whether tort**
+**(including negligence), contract, or otherwise, shall any**
+**Contributor, or anyone who distributes Covered Software as**
+**permitted above, be liable to You for any direct, indirect,**
+**special, incidental, or consequential damages of any character**
+**including, without limitation, damages for lost profits, loss of**
+**goodwill, work stoppage, computer failure or malfunction, or any**
+**and all other commercial damages or losses, even if such party**
+**shall have been informed of the possibility of such damages. This**
+**limitation of liability shall not apply to liability for death or**
+**personal injury resulting from such party's negligence to the**
+**extent applicable law prohibits such limitation. Some**
+**jurisdictions do not allow the exclusion or limitation of**
+**incidental or consequential damages, so this exclusion and**
+**limitation may not apply to You.**
+
+8. Litigation
+
+   -------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   ----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.
+
+
+parking
+-------
+Website: https://github.com/smol-rs/parking
+
+Copyright 2014-2020 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of parking for more information.
+
+
+parking_lot
+-----------
+Website: https://github.com/Amanieu/parking_lot
+
+Copyright 2016 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of parking_lot for more information.
+
+MIT License text:
+
+Copyright (c) 2016 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+pem
+---
+Website: https://github.com/jcreekmore/pem-rs
+
+Copyright 2016 Jonathan Creekmore
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Jonathan Creekmore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+pin-project
+-----------
+Website: https://github.com/taiki-e/pin-project
+
+Published by Taiki Endo
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of pin-project for more information.
+
+
+pin-project-lite
+----------------
+Website: https://github.com/taiki-e/pin-project-lite
+
+Published by Taiki Endo
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of pin-project-lite for more information.
+
+
+pin-utils
+---------
+Website: https://github.com/rust-lang-nursery/pin-utils
+
+Copyright 2018 The pin-utils authors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of pin-utils for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2018 The pin-utils authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2018 The pin-utils authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+pkg-config
+----------
+Website: https://github.com/rust-lang/pkg-config-rs
+
+Copyright 2014 Alex Crichton
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of pkg-config for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+powerfmt
+--------
+Website: https://github.com/jhpratt/powerfmt
+
+Copyright 2023 Jacob Pratt et al.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of powerfmt for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2023 Jacob Pratt et al.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2023 Jacob Pratt et al.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+ppv-lite86
+----------
+Website: https://github.com/cryptocorrosion/cryptocorrosion
+
+Copyright 2019 The CryptoCorrosion Contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of ppv-lite86 for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2019 The CryptoCorrosion Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2019 The CryptoCorrosion Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+proc-macro-error
+----------------
+Website: https://gitlab.com/CreepySkeleton/proc-macro-error
+
+Copyright 2019-2020 CreepySkeleton <creepy-skeleton@yandex.ru>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of proc-macro-error for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2019-2020 CreepySkeleton <creepy-skeleton@yandex.ru>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2019-2020 CreepySkeleton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+proc-macro2
+-----------
+Website: https://github.com/dtolnay/proc-macro2
+
+Published by David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of proc-macro2 for more information.
+
+
+quote
+-----
+Website: https://github.com/dtolnay/quote
+
+Published by David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of quote for more information.
+
+
+rand
+----
+Website: https://github.com/rust-random/rand
+
+Copyright 2014 The Rust Project Developers
+Copyright 2018 Developers of the Rand project
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of rand for more information.
+
+MIT License text:
+
+Copyright 2018 Developers of the Rand project
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+rayon
+-----
+Website: https://github.com/rayon-rs/rayon
+
+Copyright 2010 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of rayon for more information.
+
+MIT License text:
+
+Copyright (c) 2010 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+redox_syscall
+-------------
+Website: https://gitlab.redox-os.org/redox-os/syscall
+
+Copyright 2017 Redox OS Developers
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2017 Redox OS Developers
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+redox_users
+-----------
+Website: https://gitlab.redox-os.org/redox-os/users
+
+Copyright 2017 Jose Narvaez
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Jose Narvaez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+regex
+-----
+Website: https://github.com/rust-lang/regex
+
+Copyright 2014 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of regex for more information.
+
+MIT License text:
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+ring
+----
+Website: https://github.com/briansmith/ring
+
+Copyright 2009 The Go Authors.
+Copyright 2015 The Chromium Authors.
+Copyright 2015-2025 Brian Smith.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    BoringSSL license
+    ISC License
+    MIT License
+Consult the documentation and source code of ring for more information.
+
+License text (Apache License version 2.0, BoringSSL license, ISC License, MIT License):
+
+**ring** uses an "ISC" license, like BoringSSL used to use, for new code
+files. See LICENSE-other-bits for the text of that license.
+
+See LICENSE-BoringSSL for code that was sourced from BoringSSL under the
+Apache 2.0 license. Some code that was sourced from BoringSSL under the ISC
+license. In each case, the license info is at the top of the file.
+
+See src/polyfill/once_cell/LICENSE-APACHE and src/polyfill/once_cell/LICENSE-MIT
+for the license to code that was sourced from the once_cell project.
+
+
+Rust standard libraries
+-----------------------
+Website: https://github.com/rust-lang/rust
+
+Copyright (c) The Rust Project Contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of Rust standard libraries for more information.
+
+
+rust-security-framework
+-----------------------
+Website: https://github.com/kornelski/rust-security-framework
+
+Copyright 2015 Steven Fackler
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of rust-security-framework for more information.
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Steven Fackler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+rust-url
+--------
+Website: https://github.com/servo/rust-url/
+
+Copyright 2013-2022 The rust-url developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of rust-url for more information.
+
+MIT License text:
+
+Copyright (c) 2013-2022 The rust-url developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+rustc-demangle
+--------------
+Website: https://github.com/rust-lang/rustc-demangle
+
+Copyright 2014 Alex Crichton
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of rustc-demangle for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+rustix
+------
+Website: https://github.com/bytecodealliance/rustix
+
+Published by Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0 with LLVM Exceptions
+    MIT License
+Consult the documentation and source code of rustix for more information.
+
+
+ryu
+---
+Website: https://github.com/dtolnay/ryu
+
+Published by David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    Boost Software License
+Consult the documentation and source code of ryu for more information.
+
+Boost Software License text:
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+safemem
+-------
+Website: https://github.com/abonander/safemem
+
+Copyright 2016 The `multipart` Crate Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of safemem for more information.
+
+MIT License text:
+
+Copyright (c) 2016 The `multipart` Crate Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+schannel
+--------
+Website: https://github.com/steffengy/schannel-rs
+
+Copyright 2015 steffengy
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2015 steffengy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+scopeguard
+----------
+Website: https://github.com/bluss/scopeguard
+
+Copyright 2016-2019 Ulrik Sverdrup "bluss" and scopeguard developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of scopeguard for more information.
+
+MIT License text:
+
+Copyright (c) 2016-2019 Ulrik Sverdrup "bluss" and scopeguard developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+serde
+-----
+Website: https://github.com/serde-rs/serde
+
+Published by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of serde for more information.
+
+
+serde_ignored
+-------------
+Website: https://github.com/dtolnay/serde-ignored
+
+Published by David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of serde_ignored for more information.
+
+
+serde_json
+----------
+Website: https://github.com/serde-rs/json
+
+Published by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of serde_json for more information.
+
+
+serde_with
+----------
+Website: https://github.com/jonasbb/serde_with/
+
+Copyright 2015 Jonas Bushart, Marcin Kaźmierczak
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of serde_with for more information.
+
+MIT License text:
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+serde_with_macros
+-----------------
+Website: https://github.com/jonasbb/serde_with/
+
+Copyright 2015 Jonas Bushart
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of serde_with_macros for more information.
+
+MIT License text:
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+shlex
+-----
+Website: https://github.com/comex/rust-shlex
+
+Copyright 2015 Nicholas Allegra (comex).
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of shlex for more information.
+
+Apache License version 2.0 text:
+
+Copyright 2015 Nicholas Allegra (comex).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Nicholas Allegra (comex).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+signal-hook-registry
+--------------------
+Website: https://github.com/vorner/signal-hook
+
+Copyright 2017 tokio-jsonrpc developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of signal-hook-registry for more information.
+
+MIT License text:
+
+Copyright (c) 2017 tokio-jsonrpc developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+simplelog
+---------
+Website: https://github.com/drakulix/simplelog.rs
+
+Copyright 2015 Victor Brekenfeld
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of simplelog for more information.
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Victor Brekenfeld
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+simple_asn1
+-----------
+Website: https://github.com/acw/simple_asn1
+
+Copyright 2017 Adam Wick
+Distributed under the ISC License
+
+ISC License text:
+
+Copyright (c) 2017 Adam Wick
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+
+simple_logger
+-------------
+Website: https://github.com/borntyping/rust-simple_logger
+
+Copyright 2015-2021 Sam Clements
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright 2015-2021 Sam Clements
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+slab
+----
+Website: https://github.com/tokio-rs/slab
+
+Copyright 2019 Carl Lerche
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2019 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+slog
+----
+Website: https://github.com/slog-rs/slog
+
+Copyright 2014 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+    Mozilla Public License version 2.0
+Consult the documentation and source code of slog for more information.
+
+MIT License text:
+
+Copyright (c) 2014 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+Mozilla Public License version 2.0 text:
+
+Mozilla Public License Version 2.0
+
+==================================
+
+1. Definitions
+
+   --------------
+
+1.1. "Contributor"
+
+means each individual or legal entity that creates, contributes to
+the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+means the combination of the Contributions of others (if any) used
+by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+means Source Code Form to which the initial Contributor has attached
+the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+means
+
+a) that the initial Contributor has attached the notice described
+    in Exhibit B to the Covered Software; or
+
+b) that the Covered Software was made available under the terms of
+    version 1.1 or earlier of the License, but not also under the
+    terms of a Secondary License.
+
+1.6. "Executable Form"
+
+means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+means a work that combines Covered Software with other material, in
+a separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+means this document.
+
+1.9. "Licensable"
+
+means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
+
+1.10. "Modifications"
+
+means any of the following:
+
+a) any file in Source Code Form that results from an addition to,
+    deletion from, or modification of the contents of Covered
+    Software; or
+
+b) any new file in Source Code Form that contains any Covered
+    Software.
+
+1.11. "Patent Claims" of a Contributor
+
+means any patent claim(s), including without limitation, method,
+process, and apparatus claims, in any patent Licensable by such
+Contributor that would be infringed, but for the grant of the
+License, by the making, using, selling, offering for sale, having
+made, import, or transfer of either its Contributions or its
+Contributor Version.
+
+1.12. "Secondary License"
+
+means either the GNU General Public License, Version 2.0, the GNU
+Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those
+licenses.
+
+1.13. "Source Code Form"
+
+means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+means an individual or a legal entity exercising rights under this
+License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For
+purposes of this definition, "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of more than
+fifty percent (50%) of the outstanding shares or beneficial
+ownership of such entity.
+
+2. License Grants and Conditions
+
+   --------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+a) for any code that a Contributor has removed from Covered Software;
+    or
+
+b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+    This License does not grant any rights in the trademarks, service marks,
+    or logos of any Contributor (except as may be necessary to comply with
+    the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+
+   -------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+   ---------------------------------------------------
+
+   If it is impossible for You to comply with any of the terms of this
+   License with respect to some or all of the Covered Software due to
+   statute, judicial order, or regulation then You must: (a) comply with
+   the terms of this License to the maximum extent possible; and (b)
+   describe the limitations and the code they affect. Such description must
+   be placed in a text file included with all distributions of the Covered
+   Software under this License. Except to the extent prohibited by statute
+   or regulation, such description must be sufficiently detailed for a
+   recipient of ordinary skill to be able to understand it.
+
+5. Termination
+
+   --------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+**6. Disclaimer of Warranty**
+
+**-------------------------**
+
+**Covered Software is provided under this License on an "as is"**
+**basis, without warranty of any kind, either expressed, implied, or**
+**statutory, including, without limitation, warranties that the**
+**Covered Software is free of defects, merchantable, fit for a**
+**particular purpose or non-infringing. The entire risk as to the**
+**quality and performance of the Covered Software is with You.**
+**Should any Covered Software prove defective in any respect, You**
+**(not any Contributor) assume the cost of any necessary servicing,**
+**repair, or correction. This disclaimer of warranty constitutes an**
+**essential part of this License. No use of any Covered Software is**
+**authorized under this License except under this disclaimer.**
+
+**7. Limitation of Liability**
+
+**--------------------------**
+
+**Under no circumstances and under no legal theory, whether tort**
+**(including negligence), contract, or otherwise, shall any**
+**Contributor, or anyone who distributes Covered Software as**
+**permitted above, be liable to You for any direct, indirect,**
+**special, incidental, or consequential damages of any character**
+**including, without limitation, damages for lost profits, loss of**
+**goodwill, work stoppage, computer failure or malfunction, or any**
+**and all other commercial damages or losses, even if such party**
+**shall have been informed of the possibility of such damages. This**
+**limitation of liability shall not apply to liability for death or**
+**personal injury resulting from such party's negligence to the**
+**extent applicable law prohibits such limitation. Some**
+**jurisdictions do not allow the exclusion or limitation of**
+**incidental or consequential damages, so this exclusion and**
+**limitation may not apply to You.**
+
+8. Litigation
+
+   -------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   ----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.
+
+
+smallvec
+--------
+Website: https://github.com/servo/rust-smallvec
+
+Copyright 2018 The Servo Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of smallvec for more information.
+
+MIT License text:
+
+Copyright (c) 2018 The Servo Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+socket2
+-------
+Website: https://github.com/rust-lang/socket2
+
+Copyright 2014 Alex Crichton
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of socket2 for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+strsim
+------
+Website: https://github.com/rapidfuzz/strsim-rs
+
+Copyright 2015 Danny Guo
+Copyright 2016 Titus Wormer <tituswormer@gmail.com>
+Copyright 2018 Akash Kurdekar
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Danny Guo
+
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
+
+Copyright (c) 2018 Akash Kurdekar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+structopt
+---------
+Website: https://github.com/TeXitoi/structopt
+
+Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of structopt for more information.
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+structopt-derive
+----------------
+Website: https://github.com/TeXitoi/structopt
+
+Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of structopt-derive for more information.
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+subtle
+------
+Website: https://github.com/dalek-cryptography/subtle
+
+Copyright 2016-2017 Isis Agora Lovecruft, Henry de Valence.
+Copyright 2016-2024 Isis Agora Lovecruft.
+Distributed under the BSD 3-Clause license
+
+BSD 3-Clause license text:
+
+Copyright (c) 2016-2017 Isis Agora Lovecruft, Henry de Valence. All rights reserved.
+
+Copyright (c) 2016-2024 Isis Agora Lovecruft. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+swagger
+-------
+Website: https://github.com/Metaswitch/swagger-rs
+
+Copyright 2017 libraries.core
+Distributed under the Apache License version 2.0
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2017 libraries.core
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+syn
+---
+Website: https://github.com/dtolnay/syn
+
+Published by David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of syn for more information.
+
+
+sysinfo
+-------
+Website: https://github.com/GuillaumeGomez/sysinfo
+
+Copyright 2015 Guillaume Gomez
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Guillaume Gomez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+tempfile
+--------
+Website: https://github.com/Stebalien/tempfile
+
+Copyright 2015 Steven Allen
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of tempfile for more information.
+
+MIT License text:
+
+Copyright (c) 2015 Steven Allen
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+termcolor
+---------
+Website: https://github.com/BurntSushi/termcolor
+
+Copyright 2015 Andrew Gallant
+
+Distributed under multiple software licenses, including:
+    MIT License
+    Unlicense
+Consult the documentation and source code of termcolor for more information.
+
+
+terminal_size
+-------------
+Website: https://github.com/eminence/terminal-size
+
+Copyright 2015 The terminal-size Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of terminal_size for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The terminal-size Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+textwrap
+--------
+Website: https://github.com/mgeisler/textwrap
+
+Copyright 2016 Martin Geisler
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2016 Martin Geisler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+thiserror
+---------
+Website: https://github.com/dtolnay/thiserror
+
+Published by David Tolnay <dtolnay@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of thiserror for more information.
+
+
+time
+----
+Website: https://github.com/time-rs/time
+
+Copyright 2024 Jacob Pratt et al.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of time for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2024 Jacob Pratt et al.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2024 Jacob Pratt et al.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+time-core
+---------
+Website: https://github.com/time-rs/time
+
+Copyright 2022 Jacob Pratt et al.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of time-core for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2022 Jacob Pratt et al.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2022 Jacob Pratt et al.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+tinyvec
+-------
+Website: https://github.com/Lokathor/tinyvec
+
+Copyright 2019 Daniel "Lokathor" Gee.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+    zlib License
+Consult the documentation and source code of tinyvec for more information.
+
+zlib License text:
+
+Copyright (c) 2019 Daniel "Lokathor" Gee.
+
+This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.
+
+
+tinyvec_macros
+--------------
+Website: https://github.com/Soveu/tinyvec_macros
+
+Copyright (C) 2020 Tomasz "Soveu" Marx
+Copyright 2020 Soveu
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+    zlib License
+Consult the documentation and source code of tinyvec_macros for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2020 Tomasz "Soveu" Marx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2020 Soveu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+zlib License text:
+
+zlib License
+
+(C) 2020 Tomasz "Soveu" Marx
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+
+tokio
+-----
+Website: https://github.com/tokio-rs/tokio
+
+Copyright 2023 Tokio Contributors
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2023 Tokio Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+tokio-macros
+------------
+Website: https://github.com/tokio-rs/tokio
+
+Copyright 2019 Yoshua Wuyts
+Copyright Tokio Contributors
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2019 Yoshua Wuyts
+
+Copyright (c) Tokio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+tokio-openssl
+-------------
+Website: https://github.com/tokio-rs/tokio-openssl
+
+Copyright 2016 Tokio contributors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of tokio-openssl for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2016 Tokio contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+Copyright (c) 2016 Tokio contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+tokio-tungstenite
+-----------------
+Website: https://github.com/snapview/tokio-tungstenite
+
+Copyright 2017 Alexey Galakhov
+Copyright 2017 Daniel Abramov
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2017 Daniel Abramov
+
+Copyright (c) 2017 Alexey Galakhov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+tower-service
+-------------
+Website: https://github.com/tower-rs/tower
+
+Copyright 2019 Tower Contributors
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2019 Tower Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+tracing
+-------
+Website: https://github.com/tokio-rs/tracing
+
+Copyright 2019 Tokio Contributors
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2019 Tokio Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+try-lock
+--------
+Website: https://github.com/seanmonstar/try-lock
+
+Copyright 2016 Alex Crichton
+Copyright 2018-2023 Sean McArthur
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2018-2023 Sean McArthur
+
+Copyright (c) 2016 Alex Crichton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+tungstenite
+-----------
+Website: https://github.com/snapview/tungstenite-rs
+
+Copyright 2016 Jason Housley
+Copyright 2017 Alexey Galakhov
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of tungstenite for more information.
+
+MIT License text:
+
+Copyright (c) 2017 Alexey Galakhov
+
+Copyright (c) 2016 Jason Housley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+typenum
+-------
+Website: https://github.com/paholg/typenum
+
+Copyright 2014 Paho Lurie-Gregg
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of typenum for more information.
+
+
+unicase
+-------
+Website: https://github.com/seanmonstar/unicase
+
+Copyright 2014-2017 Sean McArthur
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of unicase for more information.
+
+MIT License text:
+
+Copyright (c) 2014-2017 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+unicode-bidi
+------------
+Website: https://github.com/servo/unicode-bidi
+
+Copyright 2015 The Rust Project Developers
+This project is copyright 2015, The Servo Project Developers (given in the file AUTHORS).
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of unicode-bidi for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+unicode-ident
+-------------
+Website: https://github.com/dtolnay/unicode-ident
+
+Copyright © 1991-2022 Unicode, Inc.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+    Unicode Data Files and Software License Agreement (2016)
+Consult the documentation and source code of unicode-ident for more information.
+
+Unicode Data Files and Software License Agreement (2016) text:
+
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+See Terms of Use <https://www.unicode.org/copyright.html>
+for definitions of Unicode Inc.’s Data Files and Software.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2022 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+a) this copyright and permission notice appear with all copies
+    of the Data Files or Software, or
+
+b) this copyright and permission notice appear in associated
+    Documentation.
+
+    THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+    ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+    IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+    NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+    DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+    DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+    TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+    PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+    Except as contained in this notice, the name of a copyright holder
+    shall not be used in advertising or otherwise to promote the sale,
+    use or other dealings in these Data Files or Software without prior
+    written authorization of the copyright holder.
+
+
+unicode-normalization
+---------------------
+Website: https://github.com/unicode-rs/unicode-normalization
+
+Copyright 2015 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of unicode-normalization for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+unicode-segmentation
+--------------------
+Website: https://github.com/unicode-rs/unicode-segmentation
+
+Copyright 2015 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of unicode-segmentation for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+unicode-width
+-------------
+Website: https://github.com/unicode-rs/unicode-width
+
+Copyright 2015 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of unicode-width for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+untrusted
+---------
+Website: https://github.com/briansmith/untrusted
+
+Copyright 2015-2016 Brian Smith.
+Distributed under the ISC License
+
+ISC License text:
+
+ // Copyright 2015-2016 Brian Smith.
+ //
+ // Permission to use, copy, modify, and/or distribute this software for any
+ // purpose with or without fee is hereby granted, provided that the above
+ // copyright notice and this permission notice appear in all copies.
+ //
+ // THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+ // WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ // MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
+ // ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ // WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+url
+---
+Website: https://github.com/servo/rust-url
+
+Copyright 2013-2022 The rust-url developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of url for more information.
+
+MIT License text:
+
+Copyright (c) 2013-2022 The rust-url developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+urlencoding
+-----------
+Website: https://github.com/kornelski/rust_urlencoding
+
+Copyright © 2016 Bertram Truong © 2021 Kornel Lesiński
+Distributed under the MIT License
+
+MIT License text:
+
+© 2016 Bertram Truong
+
+© 2021 Kornel Lesiński
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+utf-8
+-----
+Website: https://github.com/SimonSapin/rust-utf8
+
+Published by Simon Sapin <simon.sapin@exyr.org>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of utf-8 for more information.
+
+
+utf8parse
+---------
+Website: https://github.com/alacritty/vte
+
+Copyright 2016 Joe Wilm
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of utf8parse for more information.
+
+MIT License text:
+
+Copyright (c) 2016 Joe Wilm
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+uuid
+----
+Website: https://github.com/uuid-rs/uuid
+
+Copyright 2014 The Rust Project Developers
+Copyright 2018 Ashley Mannix, Christopher Armstrong, Dylan DPC, Hunar Roop Kahlon
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of uuid for more information.
+
+MIT License text:
+
+Copyright (c) 2014 The Rust Project Developers
+
+Copyright (c) 2018 Ashley Mannix, Christopher Armstrong, Dylan DPC, Hunar Roop Kahlon
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+validator
+---------
+Website: https://github.com/Keats/validator
+
+Published by Vincent Prouillet <hello@vincentprouillet.com
+Distributed under the MIT License
+
+
+vcpkg
+-----
+Website: https://github.com/mcgoo/vcpkg-rs
+
+Copyright 2017 Jim McGrath
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of vcpkg for more information.
+
+MIT License text:
+
+Copyright (c) 2017 Jim McGrath
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+vec_map
+-------
+Website: https://github.com/contain-rs/vec-map
+
+Copyright 2015 The Rust Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of vec_map for more information.
+
+MIT License text:
+
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+version_check
+-------------
+Website: https://github.com/SergioBenitez/version_check
+
+Copyright 2017-2018 Sergio Benitez
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of version_check for more information.
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2017-2018 Sergio Benitez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+want
+----
+Website: https://github.com/seanmonstar/want
+
+Copyright 2018-2019 Sean McArthur
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2018-2019 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+wasi
+----
+Website: https://github.com/bytecodealliance/wasi
+
+Published by The Cranelift Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0 with LLVM Exceptions
+    MIT License
+Consult the documentation and source code of wasi for more information.
+
+
+wasm-bindgen
+------------
+Website: https://github.com/rustwasm/wasm-bindgen
+
+Copyright 2014 Alex Crichton
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of wasm-bindgen for more information.
+
+MIT License text:
+
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+winapi
+------
+Website: https://github.com/retep998/winapi-rs
+
+Copyright 2015-2018 The winapi-rs Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of winapi for more information.
+
+MIT License text:
+
+Copyright (c) 2015-2018 The winapi-rs Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+winapi-rs
+---------
+Website: https://github.com/retep998/winapi-rs
+
+Published by Peter Atashian <retep998@gmail.com>
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of winapi-rs for more information.
+
+
+winapi-util
+-----------
+Website: https://github.com/BurntSushi/winapi-util
+
+Copyright 2017 Andrew Gallant
+
+Distributed under multiple software licenses, including:
+    MIT License
+    Unlicense
+Consult the documentation and source code of winapi-util for more information.
+
+
+windows-rs
+----------
+Website: https://github.com/microsoft/windows-rs
+
+Copyright Microsoft Corporation.
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of windows-rs for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright (c) Microsoft Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+MIT License text:
+
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE
+
+
+zerocopy
+--------
+Website: https://github.com/google/zerocopy
+
+Copyright 2023 The Fuchsia Authors
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    BSD 2-Clause license
+    MIT License
+Consult the documentation and source code of zerocopy for more information.
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2023 The Fuchsia Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+BSD 2-Clause license text:
+
+Copyright 2019 The Fuchsia Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+MIT License text:
+
+Copyright 2023 The Fuchsia Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+zeroize
+-------
+Website: https://github.com/RustCrypto/utils
+
+Copyright 2018-2021 The RustCrypto Project Developers
+
+Distributed under multiple software licenses, including:
+    Apache License version 2.0
+    MIT License
+Consult the documentation and source code of zeroize for more information.
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2018-2021 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+zeromq
+------
+Website: https://github.com/zeromq/zmq.rs
+
+Copyright 2020 Alexei Kornienko
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2020 Alexei Kornienko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/mole-overrides.toml
+++ b/mole-overrides.toml
@@ -1,0 +1,30 @@
+# ----------------------------------------------------------------------------
+# Rust dependency overrides
+# ----------------------------------------------------------------------------
+
+['rust::anstream']
+# If not renamed explicitly, gets merged into anstyle
+rename = 'anstream'
+
+['rust::anstyle-query']
+# If not renamed explicitly, gets merged into anstyle
+rename = 'anstyle-query'
+
+['rust::pin-project']
+# No attribution information anywhere to be found
+# Use author tag to indicate packager to avoid over-asserting copyright
+author = 'Taiki Endo'
+
+['rust::pin-project-lite']
+# No attribution information anywhere to be found
+# Use author tag to indicate packager to avoid over-asserting copyright
+author = 'Taiki Endo'
+
+['rust::ring']
+# unclear parsing in some versions
+license = ['MIT', 'BoringSSL', 'ISC', 'Apache-2.0']
+license_files = [['@', 'LICENSE']]
+
+['rust::typenum']
+# license file is invalid; skip it
+license_files = []

--- a/mole.toml
+++ b/mole.toml
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------------------------
+# Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+# Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+# ---------------------------------------------------------------------------------------------
+
+overrides = "mole-overrides.toml"
+
+[output.notice]
+template = "resources/licenses/NOTICE.template"
+destination = "NOTICE"
+format = "text"
+
+[formats.text]
+underline = { char="-" }
+nameless_license = """
+
+License text:
+
+%(text)s
+"""
+named_license = """
+
+%(name)s text:
+
+%(text)s
+"""
+multi_license = """
+
+License text (%(names)s):
+
+%(text)s
+"""
+
+[repos]
+KALLICHORE_PATH = "."
+
+[groups.rust]
+kallichore = ["KALLICHORE_PATH", "crates/*"]
+
+[collections]
+kallichore_collection = ["kallichore"]
+
+[spdx-overrides]
+# Contains an SPDX identifier for one of the sub-licenses
+'https://github.com/nodejs/node/raw/main/LICENSE' = ['MIT-with-additional']
+
+[rust.group]
+'anstyle-query' = 'anstyle'
+'clap_builder' = 'clap'
+'clap_derive' = 'clap'
+'clap_lex' = 'clap'
+'colorchoice' = 'anstyle'
+'frunk_core' = 'frunk'
+'frunk_derives' = 'frunk'
+'frunk_proc_macro_helpers' = 'frunk'
+'frunk_proc_macros' = 'frunk'
+'tokio-test' = 'tokio'
+'tokio-util' = 'tokio'

--- a/resources/licenses/NOTICE.template
+++ b/resources/licenses/NOTICE.template
@@ -1,0 +1,21 @@
+Licenses
+========
+
+Kallichore includes and/or derives from other open source software
+components. This document lists those components, where to find the source
+code for these components, and the full text of their license statements.
+
+You may also request a copy of the source code for any of these components
+by sending an email to info@posit.co
+
+Components used by Kallichore
+===========================
+%(kallichore_collection)s
+
+Licenses used by multiple components
+====================================
+%(shared-licenses)s
+
+Component-specific licenses
+===========================
+%(component-licenses)s


### PR DESCRIPTION
Used license-mole to generate a list of third-party dependency license information found in crates used by kallichore.

Also includes configuration files for re-running license-mole in the future.