### PR TITLE
Add RPC for executing code

### DIFF
--- a/crates/kallichore_api/.openapi-generator/FILES
+++ b/crates/kallichore_api/.openapi-generator/FILES
@@ -8,6 +8,11 @@ docs/ActiveSession.md
 docs/ClientHeartbeat.md
 docs/ConnectionInfo.md
 docs/Error.md
+docs/ExecuteOutput.md
+docs/ExecuteOutputType.md
+docs/ExecuteReply.md
+docs/ExecuteReplyStatus.md
+docs/ExecuteRequest.md
 docs/ExecutionQueue.md
 docs/InterruptMode.md
 docs/NewSession.md

--- a/crates/kallichore_api/README.md
+++ b/crates/kallichore_api/README.md
@@ -14,7 +14,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 1.0.0
-- Build date: 2026-04-08T11:56:43.534390-07:00[America/Los_Angeles]
+- Build date: 2026-04-08T15:56:17.963495-07:00[America/Los_Angeles]
 - Generator version: 7.17.0
 
 For more information, please visit [https://posit.co](https://posit.co)

--- a/crates/kallichore_api/README.md
+++ b/crates/kallichore_api/README.md
@@ -14,7 +14,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 1.0.0
-- Build date: 2026-01-06T09:23:26.564876-08:00[America/Los_Angeles]
+- Build date: 2026-04-08T11:56:43.534390-07:00[America/Los_Angeles]
 - Generator version: 7.17.0
 
 For more information, please visit [https://posit.co](https://posit.co)
@@ -145,6 +145,7 @@ Method | HTTP request | Description
 [**channels-upgrade**](docs/default_api.md#channels-upgrade) | **GET** /sessions/{session_id}/channels | Upgrade to a WebSocket or domain socket for channel communication
 [**connection-info**](docs/default_api.md#connection-info) | **GET** /sessions/{session_id}/connection_info | Get Jupyter connection information for the session
 [**delete-session**](docs/default_api.md#delete-session) | **DELETE** /sessions/{session_id} | Delete session
+[**execute-code**](docs/default_api.md#execute-code) | **POST** /sessions/{session_id}/execute | Execute code and return results
 [**get-session**](docs/default_api.md#get-session) | **GET** /sessions/{session_id} | Get session details
 [**interrupt-session**](docs/default_api.md#interrupt-session) | **POST** /sessions/{session_id}/interrupt | Interrupt session
 [**kill-session**](docs/default_api.md#kill-session) | **POST** /sessions/{session_id}/kill | Force quit session
@@ -158,6 +159,11 @@ Method | HTTP request | Description
  - [ClientHeartbeat](docs/ClientHeartbeat.md)
  - [ConnectionInfo](docs/ConnectionInfo.md)
  - [Error](docs/Error.md)
+ - [ExecuteOutput](docs/ExecuteOutput.md)
+ - [ExecuteOutputType](docs/ExecuteOutputType.md)
+ - [ExecuteReply](docs/ExecuteReply.md)
+ - [ExecuteReplyStatus](docs/ExecuteReplyStatus.md)
+ - [ExecuteRequest](docs/ExecuteRequest.md)
  - [ExecutionQueue](docs/ExecutionQueue.md)
  - [InterruptMode](docs/InterruptMode.md)
  - [NewSession](docs/NewSession.md)

--- a/crates/kallichore_api/api/openapi.yaml
+++ b/crates/kallichore_api/api/openapi.yaml
@@ -347,6 +347,51 @@ paths:
           description: Session not found
       security: []
       summary: Upgrade to a WebSocket or domain socket for channel communication
+  /sessions/{session_id}/execute:
+    post:
+      operationId: execute-code
+      parameters:
+      - explode: false
+        in: path
+        name: session_id
+        required: true
+        schema:
+          type: string
+        style: simple
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/executeRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/executeReply"
+          description: Execution completed
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+          description: Invalid request
+        "401":
+          content: {}
+          description: Unauthorized
+        "404":
+          content:
+            application/json: {}
+          description: Session not found
+        "408":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+          description: Execution timed out
+      security: []
+      summary: Execute code and return results
   /shutdown:
     post:
       operationId: shutdown-server
@@ -707,6 +752,150 @@ components:
       - length
       - pending
       type: object
+    executeRequest:
+      description: A request to execute code in a session
+      properties:
+        code:
+          description: The code to execute
+          type: string
+        silent:
+          default: false
+          description: "If true, signals the kernel to execute quietly: no broadcast\
+            \ on iopub, no execute_result, and the execution_count is not incremented.\
+            \ Defaults to false."
+          type: boolean
+        store_history:
+          default: true
+          description: "If true (default), the code is stored in the kernel's history.\
+            \ Set to false for throwaway executions."
+          type: boolean
+        stop_on_error:
+          default: true
+          description: "If true (default), abort the execution queue on error. If\
+            \ false, queued execute requests will still be processed even if this\
+            \ one fails."
+          type: boolean
+        timeout_seconds:
+          description: "Maximum number of seconds to wait for execution to complete.\
+            \ If not specified, the request will block indefinitely until execution\
+            \ finishes."
+          type: integer
+      required:
+      - code
+      type: object
+    executeReply:
+      description: The result of executing code in a session
+      example:
+        output:
+        - error_message: error_message
+          error_name: error_name
+          metadata: "{}"
+          stream_name: stream_name
+          data:
+            key: data
+          text: text
+          error_traceback:
+          - error_traceback
+          - error_traceback
+          type: stream
+        - error_message: error_message
+          error_name: error_name
+          metadata: "{}"
+          stream_name: stream_name
+          data:
+            key: data
+          text: text
+          error_traceback:
+          - error_traceback
+          - error_traceback
+          type: stream
+        error_message: error_message
+        error_name: error_name
+        data:
+          key: data
+        execution_count: 0
+        error_traceback:
+        - error_traceback
+        - error_traceback
+        status: ok
+      properties:
+        status:
+          $ref: "#/components/schemas/executeReply_status"
+        execution_count:
+          description: The kernel's execution counter
+          type: integer
+        output:
+          description: "All output messages produced during execution, in order"
+          items:
+            $ref: "#/components/schemas/executeOutput"
+          type: array
+        data:
+          additionalProperties:
+            type: string
+          description: "The execution result as a MIME-keyed dictionary (from execute_result),\
+            \ if the execution produced a result"
+          type: object
+        error_name:
+          description: "The error name, if the execution failed"
+          type: string
+        error_message:
+          description: "The error message, if the execution failed"
+          type: string
+        error_traceback:
+          description: "The error traceback, if the execution failed"
+          items:
+            type: string
+          type: array
+      required:
+      - execution_count
+      - output
+      - status
+      type: object
+    executeOutput:
+      description: A single output message produced during code execution
+      example:
+        error_message: error_message
+        error_name: error_name
+        metadata: "{}"
+        stream_name: stream_name
+        data:
+          key: data
+        text: text
+        error_traceback:
+        - error_traceback
+        - error_traceback
+        type: stream
+      properties:
+        type:
+          $ref: "#/components/schemas/executeOutput_type"
+        stream_name:
+          description: "The stream name (stdout or stderr), for stream output"
+          type: string
+        text:
+          description: "The text content, for stream output"
+          type: string
+        data:
+          additionalProperties:
+            type: string
+          description: "MIME-keyed data, for display_data output"
+          type: object
+        metadata:
+          description: "Metadata dictionary, for display_data output"
+          type: object
+        error_name:
+          description: "The error name, for error output"
+          type: string
+        error_message:
+          description: "The error message, for error output"
+          type: string
+        error_traceback:
+          description: "The error traceback lines, for error output"
+          items:
+            type: string
+          type: array
+      required:
+      - type
+      type: object
     activeSession:
       example:
         process_id: 6
@@ -1037,6 +1226,19 @@ components:
       required:
       - session_id
       type: object
+    executeReply_status:
+      description: Whether the execution succeeded or errored
+      enum:
+      - ok
+      - error
+      type: string
+    executeOutput_type:
+      description: The output message type
+      enum:
+      - stream
+      - display_data
+      - error
+      type: string
     serverConfiguration_log_level:
       description: The current log level
       enum:

--- a/crates/kallichore_api/bin/cli.rs
+++ b/crates/kallichore_api/bin/cli.rs
@@ -8,10 +8,10 @@ use log::{debug, info};
 use kallichore_api::{
     models, AdoptSessionResponse, ApiNoContext, ChannelsUpgradeResponse, Client,
     ClientHeartbeatResponse, ConnectionInfoResponse, ContextWrapperExt, DeleteSessionResponse,
-    GetServerConfigurationResponse, GetSessionResponse, InterruptSessionResponse,
-    KillSessionResponse, ListSessionsResponse, NewSessionResponse, RestartSessionResponse,
-    ServerStatusResponse, SetServerConfigurationResponse, ShutdownServerResponse,
-    StartSessionResponse,
+    ExecuteCodeResponse, GetServerConfigurationResponse, GetSessionResponse,
+    InterruptSessionResponse, KillSessionResponse, ListSessionsResponse, NewSessionResponse,
+    RestartSessionResponse, ServerStatusResponse, SetServerConfigurationResponse,
+    ShutdownServerResponse, StartSessionResponse,
 };
 use simple_logger::SimpleLogger;
 use swagger::{AuthData, ContextBuilder, EmptyContext, Push, XSpanIdString};
@@ -106,6 +106,12 @@ enum Operation {
     ConnectionInfo { session_id: String },
     /// Delete session
     DeleteSession { session_id: String },
+    /// Execute code and return results
+    ExecuteCode {
+        session_id: String,
+        #[clap(value_parser = parse_json::<models::ExecuteRequest>)]
+        execute_request: models::ExecuteRequest,
+    },
     /// Get session details
     GetSession { session_id: String },
     /// Interrupt session
@@ -375,6 +381,29 @@ async fn main() -> Result<()> {
                 }
                 DeleteSessionResponse::Unauthorized => "Unauthorized\n".to_string(),
                 DeleteSessionResponse::SessionNotFound => "SessionNotFound\n".to_string(),
+            }
+        }
+        Operation::ExecuteCode {
+            session_id,
+            execute_request,
+        } => {
+            info!("Performing a ExecuteCode request on {:?}", (&session_id));
+
+            let result = client.execute_code(session_id, execute_request).await?;
+            debug!("Result: {:?}", result);
+
+            match result {
+                ExecuteCodeResponse::ExecutionCompleted(body) => {
+                    "ExecutionCompleted\n".to_string() + &serde_json::to_string_pretty(&body)?
+                }
+                ExecuteCodeResponse::InvalidRequest(body) => {
+                    "InvalidRequest\n".to_string() + &serde_json::to_string_pretty(&body)?
+                }
+                ExecuteCodeResponse::Unauthorized => "Unauthorized\n".to_string(),
+                ExecuteCodeResponse::SessionNotFound => "SessionNotFound\n".to_string(),
+                ExecuteCodeResponse::ExecutionTimedOut(body) => {
+                    "ExecutionTimedOut\n".to_string() + &serde_json::to_string_pretty(&body)?
+                }
             }
         }
         Operation::GetSession { session_id } => {

--- a/crates/kallichore_api/docs/ExecuteOutput.md
+++ b/crates/kallichore_api/docs/ExecuteOutput.md
@@ -1,0 +1,17 @@
+# ExecuteOutput
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**r#type** | [***models::ExecuteOutputType**](executeOutput_type.md) |  | 
+**stream_name** | **String** | The stream name (stdout or stderr), for stream output | [optional] [default to None]
+**text** | **String** | The text content, for stream output | [optional] [default to None]
+**data** | **std::collections::HashMap<String, String>** | MIME-keyed data, for display_data output | [optional] [default to None]
+**metadata** | [***serde_json::Value**](.md) | Metadata dictionary, for display_data output | [optional] [default to None]
+**error_name** | **String** | The error name, for error output | [optional] [default to None]
+**error_message** | **String** | The error message, for error output | [optional] [default to None]
+**error_traceback** | **Vec<String>** | The error traceback lines, for error output | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/crates/kallichore_api/docs/ExecuteOutputType.md
+++ b/crates/kallichore_api/docs/ExecuteOutputType.md
@@ -1,0 +1,9 @@
+# ExecuteOutputType
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/crates/kallichore_api/docs/ExecuteReply.md
+++ b/crates/kallichore_api/docs/ExecuteReply.md
@@ -1,0 +1,16 @@
+# ExecuteReply
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**status** | [***models::ExecuteReplyStatus**](executeReply_status.md) |  | 
+**execution_count** | **i32** | The kernel's execution counter | 
+**output** | [**Vec<models::ExecuteOutput>**](executeOutput.md) | All output messages produced during execution, in order | 
+**data** | **std::collections::HashMap<String, String>** | The execution result as a MIME-keyed dictionary (from execute_result), if the execution produced a result | [optional] [default to None]
+**error_name** | **String** | The error name, if the execution failed | [optional] [default to None]
+**error_message** | **String** | The error message, if the execution failed | [optional] [default to None]
+**error_traceback** | **Vec<String>** | The error traceback, if the execution failed | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/crates/kallichore_api/docs/ExecuteReplyStatus.md
+++ b/crates/kallichore_api/docs/ExecuteReplyStatus.md
@@ -1,0 +1,9 @@
+# ExecuteReplyStatus
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/crates/kallichore_api/docs/ExecuteRequest.md
+++ b/crates/kallichore_api/docs/ExecuteRequest.md
@@ -1,0 +1,14 @@
+# ExecuteRequest
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**code** | **String** | The code to execute | 
+**silent** | **bool** | If true, signals the kernel to execute quietly: no broadcast on iopub, no execute_result, and the execution_count is not incremented. Defaults to false. | [optional] [default to Some(false)]
+**store_history** | **bool** | If true (default), the code is stored in the kernel's history. Set to false for throwaway executions. | [optional] [default to Some(true)]
+**stop_on_error** | **bool** | If true (default), abort the execution queue on error. If false, queued execute requests will still be processed even if this one fails. | [optional] [default to Some(true)]
+**timeout_seconds** | **i32** | Maximum number of seconds to wait for execution to complete. If not specified, the request will block indefinitely until execution finishes. | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/crates/kallichore_api/docs/default_api.md
+++ b/crates/kallichore_api/docs/default_api.md
@@ -15,6 +15,7 @@ Method | HTTP request | Description
 **channels-upgrade**](default_api.md#channels-upgrade) | **GET** /sessions/{session_id}/channels | Upgrade to a WebSocket or domain socket for channel communication
 **connection-info**](default_api.md#connection-info) | **GET** /sessions/{session_id}/connection_info | Get Jupyter connection information for the session
 **delete-session**](default_api.md#delete-session) | **DELETE** /sessions/{session_id} | Delete session
+**execute-code**](default_api.md#execute-code) | **POST** /sessions/{session_id}/execute | Execute code and return results
 **get-session**](default_api.md#get-session) | **GET** /sessions/{session_id} | Get session details
 **interrupt-session**](default_api.md#interrupt-session) | **POST** /sessions/{session_id}/interrupt | Interrupt session
 **kill-session**](default_api.md#kill-session) | **POST** /sessions/{session_id}/kill | Force quit session
@@ -282,6 +283,32 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **execute-code**
+> models::ExecuteReply execute-code(session_id, execute_request)
+Execute code and return results
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **session_id** | **String**|  | 
+  **execute_request** | [**ExecuteRequest**](ExecuteRequest.md)|  | 
+
+### Return type
+
+[**models::ExecuteReply**](executeReply.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/crates/kallichore_api/examples/client/main.rs
+++ b/crates/kallichore_api/examples/client/main.rs
@@ -7,10 +7,10 @@ use futures::{future, stream, Stream};
 use kallichore_api::{
     models, AdoptSessionResponse, Api, ApiNoContext, ChannelsUpgradeResponse, Claims, Client,
     ClientHeartbeatResponse, ConnectionInfoResponse, ContextWrapperExt, DeleteSessionResponse,
-    GetServerConfigurationResponse, GetSessionResponse, InterruptSessionResponse,
-    KillSessionResponse, ListSessionsResponse, NewSessionResponse, RestartSessionResponse,
-    ServerStatusResponse, SetServerConfigurationResponse, ShutdownServerResponse,
-    StartSessionResponse,
+    ExecuteCodeResponse, GetServerConfigurationResponse, GetSessionResponse,
+    InterruptSessionResponse, KillSessionResponse, ListSessionsResponse, NewSessionResponse,
+    RestartSessionResponse, ServerStatusResponse, SetServerConfigurationResponse,
+    ShutdownServerResponse, StartSessionResponse,
 };
 
 // NOTE: Set environment variable RUST_LOG to the name of the executable (or "cargo run") to activate console logging for all loglevels.
@@ -54,6 +54,7 @@ fn main() {
                     "ChannelsUpgrade",
                     "ConnectionInfo",
                     "DeleteSession",
+                    "ExecuteCode",
                     "GetSession",
                     "InterruptSession",
                     "KillSession",
@@ -227,6 +228,15 @@ fn main() {
                 (client.context() as &dyn Has<XSpanIdString>).get().clone()
             );
         }
+        /* Disabled because there's no example.
+        Some("ExecuteCode") => {
+            let result = rt.block_on(client.execute_code(
+                  "session_id_example".to_string(),
+                  ???
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        */
         Some("GetSession") => {
             let result = rt.block_on(client.get_session("session_id_example".to_string()));
             info!(

--- a/crates/kallichore_api/examples/server/server.rs
+++ b/crates/kallichore_api/examples/server/server.rs
@@ -20,8 +20,8 @@ use tokio::net::TcpListener;
 
 use kallichore_api::models;
 
-/// Builds an SSL implementation for Simple HTTPS from some hard-coded file names
-pub async fn create(addr: &str, https: bool) {
+/// Creates an HTTP server (HTTPS/TLS support removed)
+pub async fn create(addr: &str, #[allow(unused_variables)] https: bool) {
     let addr: SocketAddr = addr.parse().expect("Failed to parse bind address");
     let listener = TcpListener::bind(&addr).await.unwrap();
 
@@ -33,6 +33,38 @@ pub async fn create(addr: &str, https: bool) {
     #[allow(unused_mut)]
     let mut service =
         kallichore_api::server::context::MakeAddContext::<_, EmptyContext>::new(service);
+
+    info!("Starting a server (over http, so no TLS)");
+    println!("Listening on http://{}", addr);
+
+    loop {
+        // When an incoming TCP connection is received grab a TCP stream for
+        // client<->server communication.
+        //
+        // Note, this is a .await point, this loop will loop forever but is not a busy loop. The
+        // .await point allows the Tokio runtime to pull the task off of the thread until the task
+        // has work to do. In this case, a connection arrives on the port we are listening on and
+        // the task is woken up, at which point the task is then put back on a thread, and is
+        // driven forward by the runtime, eventually yielding a TCP stream.
+        let (tcp_stream, addr) = listener
+            .accept()
+            .await
+            .expect("Failed to accept connection");
+
+        let service = service.call(addr).await.unwrap();
+        let io = TokioIo::new(tcp_stream);
+        // Spin up a new task in Tokio so we can continue to listen for new TCP connection on the
+        // current task without waiting for the processing of the HTTP1 connection we just received
+        // to finish
+        tokio::task::spawn(async move {
+            // Handle the connection from the client using HTTP1 and pass any
+            // HTTP requests received on that connection to the `hello` function
+            let result = http1::Builder::new().serve_connection(io, service).await;
+            if let Err(err) = result {
+                println!("Error serving connection: {err:?}");
+            }
+        });
+    }
 }
 
 #[derive(Copy)]

--- a/crates/kallichore_api/examples/server/server.rs
+++ b/crates/kallichore_api/examples/server/server.rs
@@ -18,11 +18,10 @@ use swagger::EmptyContext;
 use swagger::{Has, XSpanIdString};
 use tokio::net::TcpListener;
 
-
 use kallichore_api::models;
 
-/// Creates an HTTP server (HTTPS/TLS support removed)
-pub async fn create(addr: &str, #[allow(unused_variables)] https: bool) {
+/// Builds an SSL implementation for Simple HTTPS from some hard-coded file names
+pub async fn create(addr: &str, https: bool) {
     let addr: SocketAddr = addr.parse().expect("Failed to parse bind address");
     let listener = TcpListener::bind(&addr).await.unwrap();
 
@@ -34,38 +33,6 @@ pub async fn create(addr: &str, #[allow(unused_variables)] https: bool) {
     #[allow(unused_mut)]
     let mut service =
         kallichore_api::server::context::MakeAddContext::<_, EmptyContext>::new(service);
-
-    info!("Starting a server (over http, no TLS support)");
-    println!("Listening on http://{}", addr);
-
-    loop {
-        // When an incoming TCP connection is received grab a TCP stream for
-        // client<->server communication.
-        //
-        // Note, this is a .await point, this loop will loop forever but is not a busy loop. The
-        // .await point allows the Tokio runtime to pull the task off of the thread until the task
-        // has work to do. In this case, a connection arrives on the port we are listening on and
-        // the task is woken up, at which point the task is then put back on a thread, and is
-        // driven forward by the runtime, eventually yielding a TCP stream.
-        let (tcp_stream, addr) = listener
-            .accept()
-            .await
-            .expect("Failed to accept connection");
-
-        let service = service.call(addr).await.unwrap();
-        let io = TokioIo::new(tcp_stream);
-        // Spin up a new task in Tokio so we can continue to listen for new TCP connection on the
-        // current task without waiting for the processing of the HTTP1 connection we just received
-        // to finish
-        tokio::task::spawn(async move {
-            // Handle the connection from the client using HTTP1 and pass any
-            // HTTP requests received on that connection to the `hello` function
-            let result = http1::Builder::new().serve_connection(io, service).await;
-            if let Err(err) = result {
-                println!("Error serving connection: {err:?}");
-            }
-        });
-    }
 }
 
 #[derive(Copy)]
@@ -100,10 +67,11 @@ use swagger::auth::Authorization;
 use kallichore_api::server::MakeService;
 use kallichore_api::{
     AdoptSessionResponse, Api, ChannelsUpgradeResponse, ClientHeartbeatResponse,
-    ConnectionInfoResponse, DeleteSessionResponse, GetServerConfigurationResponse,
-    GetSessionResponse, InterruptSessionResponse, KillSessionResponse, ListSessionsResponse,
-    NewSessionResponse, RestartSessionResponse, ServerStatusResponse,
-    SetServerConfigurationResponse, ShutdownServerResponse, StartSessionResponse,
+    ConnectionInfoResponse, DeleteSessionResponse, ExecuteCodeResponse,
+    GetServerConfigurationResponse, GetSessionResponse, InterruptSessionResponse,
+    KillSessionResponse, ListSessionsResponse, NewSessionResponse, RestartSessionResponse,
+    ServerStatusResponse, SetServerConfigurationResponse, ShutdownServerResponse,
+    StartSessionResponse,
 };
 use std::error::Error;
 use swagger::ApiError;
@@ -241,6 +209,22 @@ where
         info!(
             "delete_session(\"{}\") - X-Span-ID: {:?}",
             session_id,
+            context.get().0.clone()
+        );
+        Err(ApiError("Api-Error: Operation is NOT implemented".into()))
+    }
+
+    /// Execute code and return results
+    async fn execute_code(
+        &self,
+        session_id: String,
+        execute_request: models::ExecuteRequest,
+        context: &C,
+    ) -> Result<ExecuteCodeResponse, ApiError> {
+        info!(
+            "execute_code(\"{}\", {:?}) - X-Span-ID: {:?}",
+            session_id,
+            execute_request,
             context.get().0.clone()
         );
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))

--- a/crates/kallichore_api/src/client/mod.rs
+++ b/crates/kallichore_api/src/client/mod.rs
@@ -50,10 +50,11 @@ const ID_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'|');
 
 use crate::{
     AdoptSessionResponse, Api, ChannelsUpgradeResponse, ClientHeartbeatResponse,
-    ConnectionInfoResponse, DeleteSessionResponse, GetServerConfigurationResponse,
-    GetSessionResponse, InterruptSessionResponse, KillSessionResponse, ListSessionsResponse,
-    NewSessionResponse, RestartSessionResponse, ServerStatusResponse,
-    SetServerConfigurationResponse, ShutdownServerResponse, StartSessionResponse,
+    ConnectionInfoResponse, DeleteSessionResponse, ExecuteCodeResponse,
+    GetServerConfigurationResponse, GetSessionResponse, InterruptSessionResponse,
+    KillSessionResponse, ListSessionsResponse, NewSessionResponse, RestartSessionResponse,
+    ServerStatusResponse, SetServerConfigurationResponse, ShutdownServerResponse,
+    StartSessionResponse,
 };
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
@@ -1505,6 +1506,144 @@ where
             }
             401 => Ok(DeleteSessionResponse::Unauthorized),
             404 => Ok(DeleteSessionResponse::SessionNotFound),
+            code => {
+                let headers = response.headers().clone();
+                let body = http_body_util::BodyExt::collect(response.into_body())
+                    .await
+                    .map(|f| f.to_bytes().to_vec());
+                Err(ApiError(format!(
+                    "Unexpected response code {code}:\n{headers:?}\n\n{}",
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {e:?}>"),
+                        },
+                        Err(e) => format!(
+                            "<Failed to read body: {}>",
+                            Into::<crate::ServiceError>::into(e)
+                        ),
+                    }
+                )))
+            }
+        }
+    }
+
+    #[allow(clippy::vec_init_then_push)]
+    async fn execute_code(
+        &self,
+        param_session_id: String,
+        param_execute_request: models::ExecuteRequest,
+        context: &C,
+    ) -> Result<ExecuteCodeResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        #[allow(clippy::uninlined_format_args)]
+        let mut uri = format!(
+            "{}/sessions/{session_id}/execute",
+            self.base_path,
+            session_id = utf8_percent_encode(&param_session_id.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {err}"))),
+        };
+
+        let mut request = match Request::builder()
+            .method("POST")
+            .uri(uri)
+            .body(BoxBody::new(http_body_util::Empty::new()))
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {e}"))),
+        };
+
+        // Consumes basic body
+        // Body parameter
+        let body =
+            serde_json::to_string(&param_execute_request).expect("impossible to fail to serialize");
+        *request.body_mut() = body_from_string(body);
+
+        let header = "application/json";
+        request
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static(header));
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {e}"
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {e}")))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = http_body_util::BodyExt::collect(body)
+                    .await
+                    .map(|f| f.to_bytes().to_vec())
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e.into())))?;
+
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {e}")))?;
+                let body = serde_json::from_str::<models::ExecuteReply>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {e}"))
+                })?;
+
+                Ok(ExecuteCodeResponse::ExecutionCompleted(body))
+            }
+            400 => {
+                let body = response.into_body();
+                let body = http_body_util::BodyExt::collect(body)
+                    .await
+                    .map(|f| f.to_bytes().to_vec())
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e.into())))?;
+
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {e}")))?;
+                let body = serde_json::from_str::<models::Error>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {e}"))
+                })?;
+
+                Ok(ExecuteCodeResponse::InvalidRequest(body))
+            }
+            401 => Ok(ExecuteCodeResponse::Unauthorized),
+            404 => Ok(ExecuteCodeResponse::SessionNotFound),
+            408 => {
+                let body = response.into_body();
+                let body = http_body_util::BodyExt::collect(body)
+                    .await
+                    .map(|f| f.to_bytes().to_vec())
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e.into())))?;
+
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {e}")))?;
+                let body = serde_json::from_str::<models::Error>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {e}"))
+                })?;
+
+                Ok(ExecuteCodeResponse::ExecutionTimedOut(body))
+            }
             code => {
                 let headers = response.headers().clone();
                 let body = http_body_util::BodyExt::collect(response.into_body())

--- a/crates/kallichore_api/src/lib.rs
+++ b/crates/kallichore_api/src/lib.rs
@@ -142,6 +142,21 @@ pub enum DeleteSessionResponse {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
+pub enum ExecuteCodeResponse {
+    /// Execution completed
+    ExecutionCompleted(models::ExecuteReply),
+    /// Invalid request
+    InvalidRequest(models::Error),
+    /// Unauthorized
+    Unauthorized,
+    /// Session not found
+    SessionNotFound,
+    /// Execution timed out
+    ExecutionTimedOut(models::Error),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum GetSessionResponse {
     /// Session details
     SessionDetails(models::ActiveSession),
@@ -272,6 +287,14 @@ pub trait Api<C: Send + Sync> {
         context: &C,
     ) -> Result<DeleteSessionResponse, ApiError>;
 
+    /// Execute code and return results
+    async fn execute_code(
+        &self,
+        session_id: String,
+        execute_request: models::ExecuteRequest,
+        context: &C,
+    ) -> Result<ExecuteCodeResponse, ApiError>;
+
     /// Get session details
     async fn get_session(
         &self,
@@ -364,6 +387,13 @@ pub trait ApiNoContext<C: Send + Sync> {
 
     /// Delete session
     async fn delete_session(&self, session_id: String) -> Result<DeleteSessionResponse, ApiError>;
+
+    /// Execute code and return results
+    async fn execute_code(
+        &self,
+        session_id: String,
+        execute_request: models::ExecuteRequest,
+    ) -> Result<ExecuteCodeResponse, ApiError>;
 
     /// Get session details
     async fn get_session(&self, session_id: String) -> Result<GetSessionResponse, ApiError>;
@@ -498,6 +528,18 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     async fn delete_session(&self, session_id: String) -> Result<DeleteSessionResponse, ApiError> {
         let context = self.context().clone();
         self.api().delete_session(session_id, &context).await
+    }
+
+    /// Execute code and return results
+    async fn execute_code(
+        &self,
+        session_id: String,
+        execute_request: models::ExecuteRequest,
+    ) -> Result<ExecuteCodeResponse, ApiError> {
+        let context = self.context().clone();
+        self.api()
+            .execute_code(session_id, execute_request, &context)
+            .await
     }
 
     /// Get session details

--- a/crates/kallichore_api/src/models.rs
+++ b/crates/kallichore_api/src/models.rs
@@ -1310,6 +1310,1148 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
+/// A single output message produced during code execution
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct ExecuteOutput {
+    #[serde(rename = "type")]
+    pub r#type: models::ExecuteOutputType,
+
+    /// The stream name (stdout or stderr), for stream output
+    #[serde(rename = "stream_name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_name: Option<String>,
+
+    /// The text content, for stream output
+    #[serde(rename = "text")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+
+    /// MIME-keyed data, for display_data output
+    #[serde(rename = "data")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<std::collections::HashMap<String, String>>,
+
+    /// Metadata dictionary, for display_data output
+    #[serde(rename = "metadata")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+
+    /// The error name, for error output
+    #[serde(rename = "error_name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_name: Option<String>,
+
+    /// The error message, for error output
+    #[serde(rename = "error_message")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+
+    /// The error traceback lines, for error output
+    #[serde(rename = "error_traceback")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_traceback: Option<Vec<String>>,
+}
+
+impl ExecuteOutput {
+    #[allow(clippy::new_without_default)]
+    pub fn new(r#type: models::ExecuteOutputType) -> ExecuteOutput {
+        ExecuteOutput {
+            r#type,
+            stream_name: None,
+            text: None,
+            data: None,
+            metadata: None,
+            error_name: None,
+            error_message: None,
+            error_traceback: None,
+        }
+    }
+}
+
+/// Converts the ExecuteOutput value to the Query Parameters representation (style=form, explode=false)
+/// specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for ExecuteOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            // Skipping non-primitive type type in query parameter serialization
+            self.stream_name
+                .as_ref()
+                .map(|stream_name| ["stream_name".to_string(), stream_name.to_string()].join(",")),
+            self.text
+                .as_ref()
+                .map(|text| ["text".to_string(), text.to_string()].join(",")),
+            // Skipping map data in query parameter serialization
+            // Skipping non-primitive type metadata in query parameter serialization
+            self.error_name
+                .as_ref()
+                .map(|error_name| ["error_name".to_string(), error_name.to_string()].join(",")),
+            self.error_message.as_ref().map(|error_message| {
+                ["error_message".to_string(), error_message.to_string()].join(",")
+            }),
+            self.error_traceback.as_ref().map(|error_traceback| {
+                [
+                    "error_traceback".to_string(),
+                    error_traceback
+                        .iter()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<_>>()
+                        .join(","),
+                ]
+                .join(",")
+            }),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a ExecuteOutput value
+/// as specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for ExecuteOutput {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub r#type: Vec<models::ExecuteOutputType>,
+            pub stream_name: Vec<String>,
+            pub text: Vec<String>,
+            pub data: Vec<std::collections::HashMap<String, String>>,
+            pub metadata: Vec<serde_json::Value>,
+            pub error_name: Vec<String>,
+            pub error_message: Vec<String>,
+            pub error_traceback: Vec<Vec<String>>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing ExecuteOutput".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "type" => intermediate_rep.r#type.push(
+                        <models::ExecuteOutputType as std::str::FromStr>::from_str(val)
+                            .map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "stream_name" => intermediate_rep.stream_name.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "text" => intermediate_rep.text.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    "data" => {
+                        return std::result::Result::Err(
+                            "Parsing a container in this style is not supported in ExecuteOutput"
+                                .to_string(),
+                        )
+                    }
+                    #[allow(clippy::redundant_clone)]
+                    "metadata" => intermediate_rep.metadata.push(
+                        <serde_json::Value as std::str::FromStr>::from_str(val)
+                            .map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "error_name" => intermediate_rep.error_name.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "error_message" => intermediate_rep.error_message.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    "error_traceback" => {
+                        return std::result::Result::Err(
+                            "Parsing a container in this style is not supported in ExecuteOutput"
+                                .to_string(),
+                        )
+                    }
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing ExecuteOutput".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(ExecuteOutput {
+            r#type: intermediate_rep
+                .r#type
+                .into_iter()
+                .next()
+                .ok_or_else(|| "type missing in ExecuteOutput".to_string())?,
+            stream_name: intermediate_rep.stream_name.into_iter().next(),
+            text: intermediate_rep.text.into_iter().next(),
+            data: intermediate_rep.data.into_iter().next(),
+            metadata: intermediate_rep.metadata.into_iter().next(),
+            error_name: intermediate_rep.error_name.into_iter().next(),
+            error_message: intermediate_rep.error_message.into_iter().next(),
+            error_traceback: intermediate_rep.error_traceback.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<ExecuteOutput> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<ExecuteOutput>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<ExecuteOutput>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for ExecuteOutput - value: {hdr_value} is invalid {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ExecuteOutput> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <ExecuteOutput as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{value}' into ExecuteOutput - {err}"
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {hdr_value:?} to string: {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<ExecuteOutput>>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_values: header::IntoHeaderValue<Vec<ExecuteOutput>>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_values: Vec<String> = hdr_values
+            .0
+            .into_iter()
+            .map(|hdr_value| hdr_value.to_string())
+            .collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+            std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert {hdr_values:?} into a header - {e}",
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<Vec<ExecuteOutput>>
+{
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<ExecuteOutput> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <ExecuteOutput as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into ExecuteOutput - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to parse header: {hdr_values:?} as a string - {e}"
+            )),
+        }
+    }
+}
+
+/// The output message type
+/// Enumeration of values.
+/// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
+/// which helps with FFI.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash,
+)]
+#[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
+pub enum ExecuteOutputType {
+    #[serde(rename = "stream")]
+    Stream,
+    #[serde(rename = "display_data")]
+    DisplayData,
+    #[serde(rename = "error")]
+    Error,
+}
+
+impl std::fmt::Display for ExecuteOutputType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            ExecuteOutputType::Stream => write!(f, "stream"),
+            ExecuteOutputType::DisplayData => write!(f, "display_data"),
+            ExecuteOutputType::Error => write!(f, "error"),
+        }
+    }
+}
+
+impl std::str::FromStr for ExecuteOutputType {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "stream" => std::result::Result::Ok(ExecuteOutputType::Stream),
+            "display_data" => std::result::Result::Ok(ExecuteOutputType::DisplayData),
+            "error" => std::result::Result::Ok(ExecuteOutputType::Error),
+            _ => std::result::Result::Err(format!("Value not valid: {s}")),
+        }
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<ExecuteOutputType> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<ExecuteOutputType>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<ExecuteOutputType>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for ExecuteOutputType - value: {hdr_value} is invalid {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<ExecuteOutputType>
+{
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <ExecuteOutputType as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{value}' into ExecuteOutputType - {err}"
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {hdr_value:?} to string: {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<ExecuteOutputType>>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_values: header::IntoHeaderValue<Vec<ExecuteOutputType>>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_values: Vec<String> = hdr_values
+            .0
+            .into_iter()
+            .map(|hdr_value| hdr_value.to_string())
+            .collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+            std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert {hdr_values:?} into a header - {e}",
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<Vec<ExecuteOutputType>>
+{
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<ExecuteOutputType> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <ExecuteOutputType as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into ExecuteOutputType - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to parse header: {hdr_values:?} as a string - {e}"
+            )),
+        }
+    }
+}
+
+/// The result of executing code in a session
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct ExecuteReply {
+    #[serde(rename = "status")]
+    pub status: models::ExecuteReplyStatus,
+
+    /// The kernel's execution counter
+    #[serde(rename = "execution_count")]
+    pub execution_count: i32,
+
+    /// All output messages produced during execution, in order
+    #[serde(rename = "output")]
+    pub output: Vec<models::ExecuteOutput>,
+
+    /// The execution result as a MIME-keyed dictionary (from execute_result), if the execution produced a result
+    #[serde(rename = "data")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<std::collections::HashMap<String, String>>,
+
+    /// The error name, if the execution failed
+    #[serde(rename = "error_name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_name: Option<String>,
+
+    /// The error message, if the execution failed
+    #[serde(rename = "error_message")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+
+    /// The error traceback, if the execution failed
+    #[serde(rename = "error_traceback")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_traceback: Option<Vec<String>>,
+}
+
+impl ExecuteReply {
+    #[allow(clippy::new_without_default)]
+    pub fn new(
+        status: models::ExecuteReplyStatus,
+        execution_count: i32,
+        output: Vec<models::ExecuteOutput>,
+    ) -> ExecuteReply {
+        ExecuteReply {
+            status,
+            execution_count,
+            output,
+            data: None,
+            error_name: None,
+            error_message: None,
+            error_traceback: None,
+        }
+    }
+}
+
+/// Converts the ExecuteReply value to the Query Parameters representation (style=form, explode=false)
+/// specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for ExecuteReply {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            // Skipping non-primitive type status in query parameter serialization
+            Some("execution_count".to_string()),
+            Some(self.execution_count.to_string()),
+            // Skipping non-primitive type output in query parameter serialization
+            // Skipping map data in query parameter serialization
+            self.error_name
+                .as_ref()
+                .map(|error_name| ["error_name".to_string(), error_name.to_string()].join(",")),
+            self.error_message.as_ref().map(|error_message| {
+                ["error_message".to_string(), error_message.to_string()].join(",")
+            }),
+            self.error_traceback.as_ref().map(|error_traceback| {
+                [
+                    "error_traceback".to_string(),
+                    error_traceback
+                        .iter()
+                        .map(|x| x.to_string())
+                        .collect::<Vec<_>>()
+                        .join(","),
+                ]
+                .join(",")
+            }),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a ExecuteReply value
+/// as specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for ExecuteReply {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub status: Vec<models::ExecuteReplyStatus>,
+            pub execution_count: Vec<i32>,
+            pub output: Vec<Vec<models::ExecuteOutput>>,
+            pub data: Vec<std::collections::HashMap<String, String>>,
+            pub error_name: Vec<String>,
+            pub error_message: Vec<String>,
+            pub error_traceback: Vec<Vec<String>>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing ExecuteReply".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "status" => intermediate_rep.status.push(
+                        <models::ExecuteReplyStatus as std::str::FromStr>::from_str(val)
+                            .map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "execution_count" => intermediate_rep.execution_count.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    "output" => {
+                        return std::result::Result::Err(
+                            "Parsing a container in this style is not supported in ExecuteReply"
+                                .to_string(),
+                        )
+                    }
+                    "data" => {
+                        return std::result::Result::Err(
+                            "Parsing a container in this style is not supported in ExecuteReply"
+                                .to_string(),
+                        )
+                    }
+                    #[allow(clippy::redundant_clone)]
+                    "error_name" => intermediate_rep.error_name.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "error_message" => intermediate_rep.error_message.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    "error_traceback" => {
+                        return std::result::Result::Err(
+                            "Parsing a container in this style is not supported in ExecuteReply"
+                                .to_string(),
+                        )
+                    }
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing ExecuteReply".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(ExecuteReply {
+            status: intermediate_rep
+                .status
+                .into_iter()
+                .next()
+                .ok_or_else(|| "status missing in ExecuteReply".to_string())?,
+            execution_count: intermediate_rep
+                .execution_count
+                .into_iter()
+                .next()
+                .ok_or_else(|| "execution_count missing in ExecuteReply".to_string())?,
+            output: intermediate_rep
+                .output
+                .into_iter()
+                .next()
+                .ok_or_else(|| "output missing in ExecuteReply".to_string())?,
+            data: intermediate_rep.data.into_iter().next(),
+            error_name: intermediate_rep.error_name.into_iter().next(),
+            error_message: intermediate_rep.error_message.into_iter().next(),
+            error_traceback: intermediate_rep.error_traceback.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<ExecuteReply> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<ExecuteReply>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<ExecuteReply>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for ExecuteReply - value: {hdr_value} is invalid {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ExecuteReply> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <ExecuteReply as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{value}' into ExecuteReply - {err}"
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {hdr_value:?} to string: {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<ExecuteReply>>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_values: header::IntoHeaderValue<Vec<ExecuteReply>>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_values: Vec<String> = hdr_values
+            .0
+            .into_iter()
+            .map(|hdr_value| hdr_value.to_string())
+            .collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+            std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert {hdr_values:?} into a header - {e}",
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<Vec<ExecuteReply>>
+{
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<ExecuteReply> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <ExecuteReply as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into ExecuteReply - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to parse header: {hdr_values:?} as a string - {e}"
+            )),
+        }
+    }
+}
+
+/// Whether the execution succeeded or errored
+/// Enumeration of values.
+/// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
+/// which helps with FFI.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash,
+)]
+#[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
+pub enum ExecuteReplyStatus {
+    #[serde(rename = "ok")]
+    Ok,
+    #[serde(rename = "error")]
+    Error,
+}
+
+impl std::fmt::Display for ExecuteReplyStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            ExecuteReplyStatus::Ok => write!(f, "ok"),
+            ExecuteReplyStatus::Error => write!(f, "error"),
+        }
+    }
+}
+
+impl std::str::FromStr for ExecuteReplyStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "ok" => std::result::Result::Ok(ExecuteReplyStatus::Ok),
+            "error" => std::result::Result::Ok(ExecuteReplyStatus::Error),
+            _ => std::result::Result::Err(format!("Value not valid: {s}")),
+        }
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<ExecuteReplyStatus> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<ExecuteReplyStatus>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<ExecuteReplyStatus>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for ExecuteReplyStatus - value: {hdr_value} is invalid {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<ExecuteReplyStatus>
+{
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <ExecuteReplyStatus as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{value}' into ExecuteReplyStatus - {err}"
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {hdr_value:?} to string: {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<ExecuteReplyStatus>>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_values: header::IntoHeaderValue<Vec<ExecuteReplyStatus>>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_values: Vec<String> = hdr_values
+            .0
+            .into_iter()
+            .map(|hdr_value| hdr_value.to_string())
+            .collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+            std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert {hdr_values:?} into a header - {e}",
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<Vec<ExecuteReplyStatus>>
+{
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<ExecuteReplyStatus> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <ExecuteReplyStatus as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into ExecuteReplyStatus - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to parse header: {hdr_values:?} as a string - {e}"
+            )),
+        }
+    }
+}
+
+/// A request to execute code in a session
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct ExecuteRequest {
+    /// The code to execute
+    #[serde(rename = "code")]
+    pub code: String,
+
+    /// If true, signals the kernel to execute quietly: no broadcast on iopub, no execute_result, and the execution_count is not incremented. Defaults to false.
+    #[serde(rename = "silent")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub silent: Option<bool>,
+
+    /// If true (default), the code is stored in the kernel's history. Set to false for throwaway executions.
+    #[serde(rename = "store_history")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store_history: Option<bool>,
+
+    /// If true (default), abort the execution queue on error. If false, queued execute requests will still be processed even if this one fails.
+    #[serde(rename = "stop_on_error")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_on_error: Option<bool>,
+
+    /// Maximum number of seconds to wait for execution to complete. If not specified, the request will block indefinitely until execution finishes.
+    #[serde(rename = "timeout_seconds")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<i32>,
+}
+
+impl ExecuteRequest {
+    #[allow(clippy::new_without_default)]
+    pub fn new(code: String) -> ExecuteRequest {
+        ExecuteRequest {
+            code,
+            silent: Some(false),
+            store_history: Some(true),
+            stop_on_error: Some(true),
+            timeout_seconds: None,
+        }
+    }
+}
+
+/// Converts the ExecuteRequest value to the Query Parameters representation (style=form, explode=false)
+/// specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for ExecuteRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("code".to_string()),
+            Some(self.code.to_string()),
+            self.silent
+                .as_ref()
+                .map(|silent| ["silent".to_string(), silent.to_string()].join(",")),
+            self.store_history.as_ref().map(|store_history| {
+                ["store_history".to_string(), store_history.to_string()].join(",")
+            }),
+            self.stop_on_error.as_ref().map(|stop_on_error| {
+                ["stop_on_error".to_string(), stop_on_error.to_string()].join(",")
+            }),
+            self.timeout_seconds.as_ref().map(|timeout_seconds| {
+                ["timeout_seconds".to_string(), timeout_seconds.to_string()].join(",")
+            }),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a ExecuteRequest value
+/// as specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for ExecuteRequest {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub code: Vec<String>,
+            pub silent: Vec<bool>,
+            pub store_history: Vec<bool>,
+            pub stop_on_error: Vec<bool>,
+            pub timeout_seconds: Vec<i32>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing ExecuteRequest".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "code" => intermediate_rep.code.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "silent" => intermediate_rep.silent.push(
+                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "store_history" => intermediate_rep.store_history.push(
+                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "stop_on_error" => intermediate_rep.stop_on_error.push(
+                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "timeout_seconds" => intermediate_rep.timeout_seconds.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing ExecuteRequest".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(ExecuteRequest {
+            code: intermediate_rep
+                .code
+                .into_iter()
+                .next()
+                .ok_or_else(|| "code missing in ExecuteRequest".to_string())?,
+            silent: intermediate_rep.silent.into_iter().next(),
+            store_history: intermediate_rep.store_history.into_iter().next(),
+            stop_on_error: intermediate_rep.stop_on_error.into_iter().next(),
+            timeout_seconds: intermediate_rep.timeout_seconds.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<ExecuteRequest> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<ExecuteRequest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<ExecuteRequest>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for ExecuteRequest - value: {hdr_value} is invalid {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ExecuteRequest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <ExecuteRequest as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{value}' into ExecuteRequest - {err}"
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {hdr_value:?} to string: {e}"
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<ExecuteRequest>>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_values: header::IntoHeaderValue<Vec<ExecuteRequest>>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_values: Vec<String> = hdr_values
+            .0
+            .into_iter()
+            .map(|hdr_value| hdr_value.to_string())
+            .collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+            std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert {hdr_values:?} into a header - {e}",
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<Vec<ExecuteRequest>>
+{
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<ExecuteRequest> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <ExecuteRequest as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into ExecuteRequest - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to parse header: {hdr_values:?} as a string - {e}"
+            )),
+        }
+    }
+}
+
 /// The execution queue for a session
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]

--- a/crates/kallichore_api/src/server/mod.rs
+++ b/crates/kallichore_api/src/server/mod.rs
@@ -28,10 +28,11 @@ type ServiceFuture =
 
 use crate::{
     AdoptSessionResponse, Api, ChannelsUpgradeResponse, ClientHeartbeatResponse,
-    ConnectionInfoResponse, DeleteSessionResponse, GetServerConfigurationResponse,
-    GetSessionResponse, InterruptSessionResponse, KillSessionResponse, ListSessionsResponse,
-    NewSessionResponse, RestartSessionResponse, ServerStatusResponse,
-    SetServerConfigurationResponse, ShutdownServerResponse, StartSessionResponse,
+    ConnectionInfoResponse, DeleteSessionResponse, ExecuteCodeResponse,
+    GetServerConfigurationResponse, GetSessionResponse, InterruptSessionResponse,
+    KillSessionResponse, ListSessionsResponse, NewSessionResponse, RestartSessionResponse,
+    ServerStatusResponse, SetServerConfigurationResponse, ShutdownServerResponse,
+    StartSessionResponse,
 };
 
 mod server_auth;
@@ -48,6 +49,7 @@ mod paths {
             r"^/sessions/(?P<session_id>[^/?#]*)/adopt$",
             r"^/sessions/(?P<session_id>[^/?#]*)/channels$",
             r"^/sessions/(?P<session_id>[^/?#]*)/connection_info$",
+            r"^/sessions/(?P<session_id>[^/?#]*)/execute$",
             r"^/sessions/(?P<session_id>[^/?#]*)/interrupt$",
             r"^/sessions/(?P<session_id>[^/?#]*)/kill$",
             r"^/sessions/(?P<session_id>[^/?#]*)/restart$",
@@ -88,36 +90,43 @@ mod paths {
             regex::Regex::new(r"^/sessions/(?P<session_id>[^/?#]*)/connection_info$")
                 .expect("Unable to create regex for SESSIONS_SESSION_ID_CONNECTION_INFO");
     }
-    pub(crate) static ID_SESSIONS_SESSION_ID_INTERRUPT: usize = 7;
+    pub(crate) static ID_SESSIONS_SESSION_ID_EXECUTE: usize = 7;
+    lazy_static! {
+        pub static ref REGEX_SESSIONS_SESSION_ID_EXECUTE: regex::Regex =
+            #[allow(clippy::invalid_regex)]
+            regex::Regex::new(r"^/sessions/(?P<session_id>[^/?#]*)/execute$")
+                .expect("Unable to create regex for SESSIONS_SESSION_ID_EXECUTE");
+    }
+    pub(crate) static ID_SESSIONS_SESSION_ID_INTERRUPT: usize = 8;
     lazy_static! {
         pub static ref REGEX_SESSIONS_SESSION_ID_INTERRUPT: regex::Regex =
             #[allow(clippy::invalid_regex)]
             regex::Regex::new(r"^/sessions/(?P<session_id>[^/?#]*)/interrupt$")
                 .expect("Unable to create regex for SESSIONS_SESSION_ID_INTERRUPT");
     }
-    pub(crate) static ID_SESSIONS_SESSION_ID_KILL: usize = 8;
+    pub(crate) static ID_SESSIONS_SESSION_ID_KILL: usize = 9;
     lazy_static! {
         pub static ref REGEX_SESSIONS_SESSION_ID_KILL: regex::Regex =
             #[allow(clippy::invalid_regex)]
             regex::Regex::new(r"^/sessions/(?P<session_id>[^/?#]*)/kill$")
                 .expect("Unable to create regex for SESSIONS_SESSION_ID_KILL");
     }
-    pub(crate) static ID_SESSIONS_SESSION_ID_RESTART: usize = 9;
+    pub(crate) static ID_SESSIONS_SESSION_ID_RESTART: usize = 10;
     lazy_static! {
         pub static ref REGEX_SESSIONS_SESSION_ID_RESTART: regex::Regex =
             #[allow(clippy::invalid_regex)]
             regex::Regex::new(r"^/sessions/(?P<session_id>[^/?#]*)/restart$")
                 .expect("Unable to create regex for SESSIONS_SESSION_ID_RESTART");
     }
-    pub(crate) static ID_SESSIONS_SESSION_ID_START: usize = 10;
+    pub(crate) static ID_SESSIONS_SESSION_ID_START: usize = 11;
     lazy_static! {
         pub static ref REGEX_SESSIONS_SESSION_ID_START: regex::Regex =
             #[allow(clippy::invalid_regex)]
             regex::Regex::new(r"^/sessions/(?P<session_id>[^/?#]*)/start$")
                 .expect("Unable to create regex for SESSIONS_SESSION_ID_START");
     }
-    pub(crate) static ID_SHUTDOWN: usize = 11;
-    pub(crate) static ID_STATUS: usize = 12;
+    pub(crate) static ID_SHUTDOWN: usize = 12;
+    pub(crate) static ID_STATUS: usize = 13;
 }
 
 pub struct MakeService<T, C>
@@ -1197,6 +1206,164 @@ where
                     Ok(response)
                 }
 
+                // ExecuteCode - POST /sessions/{session_id}/execute
+                hyper::Method::POST if path.matched(paths::ID_SESSIONS_SESSION_ID_EXECUTE) => {
+                    // Path parameters
+                    let path: &str = uri.path();
+                    let path_params =
+                    paths::REGEX_SESSIONS_SESSION_ID_EXECUTE
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE SESSIONS_SESSION_ID_EXECUTE in set but failed match against \"{}\"", path, paths::REGEX_SESSIONS_SESSION_ID_EXECUTE.as_str())
+                    );
+
+                    let param_session_id = match percent_encoding::percent_decode(path_params["session_id"].as_bytes()).decode_utf8() {
+                    Ok(param_session_id) => match param_session_id.parse::<String>() {
+                        Ok(param_session_id) => param_session_id,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(body_from_string(format!("Couldn't parse path parameter session_id: {e}")))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(body_from_string(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["session_id"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                    // Handle body parameters (note that non-required body parameters will ignore garbage
+                    // values, rather than causing a 400 response). Produce warning header and logs for
+                    // any unused fields.
+                    let result = http_body_util::BodyExt::collect(body)
+                        .await
+                        .map(|f| f.to_bytes().to_vec());
+                    match result {
+                        Ok(body) => {
+                            let mut unused_elements: Vec<String> = vec![];
+                            let param_execute_request: Option<models::ExecuteRequest> = if !body
+                                .is_empty()
+                            {
+                                let deserializer = &mut serde_json::Deserializer::from_slice(&body);
+                                match serde_ignored::deserialize(deserializer, |path| {
+                                            warn!("Ignoring unknown field in body: {path}");
+                                            unused_elements.push(path.to_string());
+                                    }) {
+                                        Ok(param_execute_request) => param_execute_request,
+                                        Err(e) => return Ok(Response::builder()
+                                                        .status(StatusCode::BAD_REQUEST)
+                                                        .body(BoxBody::new(format!("Couldn't parse body parameter ExecuteRequest - doesn't match schema: {e}")))
+                                                        .expect("Unable to create Bad Request response for invalid body parameter ExecuteRequest due to schema")),
+                                    }
+                            } else {
+                                None
+                            };
+                            let param_execute_request = match param_execute_request {
+                                    Some(param_execute_request) => param_execute_request,
+                                    None => return Ok(Response::builder()
+                                                        .status(StatusCode::BAD_REQUEST)
+                                                        .body(BoxBody::new("Missing required body parameter ExecuteRequest".to_string()))
+                                                        .expect("Unable to create Bad Request response for missing body parameter ExecuteRequest")),
+                                };
+
+                            let result = api_impl
+                                .execute_code(param_session_id, param_execute_request, &context)
+                                .await;
+                            let mut response =
+                                Response::new(BoxBody::new(http_body_util::Empty::new()));
+                            response.headers_mut().insert(
+                                HeaderName::from_static("x-span-id"),
+                                HeaderValue::from_str(
+                                    (&context as &dyn Has<XSpanIdString>)
+                                        .get()
+                                        .0
+                                        .clone()
+                                        .as_str(),
+                                )
+                                .expect("Unable to create X-Span-ID header value"),
+                            );
+
+                            if !unused_elements.is_empty() {
+                                response.headers_mut().insert(
+                                    HeaderName::from_static("warning"),
+                                    HeaderValue::from_str(
+                                        format!(
+                                            "Ignoring unknown fields in body: {unused_elements:?}"
+                                        )
+                                        .as_str(),
+                                    )
+                                    .expect("Unable to create Warning header value"),
+                                );
+                            }
+                            match result {
+                                Ok(rsp) => match rsp {
+                                    ExecuteCodeResponse::ExecutionCompleted(body) => {
+                                        *response.status_mut() = StatusCode::from_u16(200)
+                                            .expect("Unable to turn 200 into a StatusCode");
+                                        response.headers_mut().insert(
+                                            CONTENT_TYPE,
+                                            HeaderValue::from_static("application/json"),
+                                        );
+                                        // JSON Body
+                                        let body = serde_json::to_string(&body)
+                                            .expect("impossible to fail to serialize");
+                                        *response.body_mut() = body_from_string(body);
+                                    }
+                                    ExecuteCodeResponse::InvalidRequest(body) => {
+                                        *response.status_mut() = StatusCode::from_u16(400)
+                                            .expect("Unable to turn 400 into a StatusCode");
+                                        response.headers_mut().insert(
+                                            CONTENT_TYPE,
+                                            HeaderValue::from_static("application/json"),
+                                        );
+                                        // JSON Body
+                                        let body = serde_json::to_string(&body)
+                                            .expect("impossible to fail to serialize");
+                                        *response.body_mut() = body_from_string(body);
+                                    }
+                                    ExecuteCodeResponse::Unauthorized => {
+                                        *response.status_mut() = StatusCode::from_u16(401)
+                                            .expect("Unable to turn 401 into a StatusCode");
+                                    }
+                                    ExecuteCodeResponse::SessionNotFound => {
+                                        *response.status_mut() = StatusCode::from_u16(404)
+                                            .expect("Unable to turn 404 into a StatusCode");
+                                    }
+                                    ExecuteCodeResponse::ExecutionTimedOut(body) => {
+                                        *response.status_mut() = StatusCode::from_u16(408)
+                                            .expect("Unable to turn 408 into a StatusCode");
+                                        response.headers_mut().insert(
+                                            CONTENT_TYPE,
+                                            HeaderValue::from_static("application/json"),
+                                        );
+                                        // JSON Body
+                                        let body = serde_json::to_string(&body)
+                                            .expect("impossible to fail to serialize");
+                                        *response.body_mut() = body_from_string(body);
+                                    }
+                                },
+                                Err(_) => {
+                                    // Application code returned an error. This should not happen, as the implementation should
+                                    // return a valid response.
+                                    *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                    *response.body_mut() =
+                                        body_from_str("An internal error occurred");
+                                }
+                            }
+
+                            Ok(response)
+                        }
+                        Err(e) => Ok(Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .body(body_from_string(format!(
+                                "Unable to read body: {}",
+                                e.into()
+                            )))
+                            .expect(
+                                "Unable to create Bad Request response due to unable to read body",
+                            )),
+                    }
+                }
+
                 // GetSession - GET /sessions/{session_id}
                 hyper::Method::GET if path.matched(paths::ID_SESSIONS_SESSION_ID) => {
                     // Path parameters
@@ -1676,6 +1843,7 @@ where
                 _ if path.matched(paths::ID_SESSIONS_SESSION_ID_CONNECTION_INFO) => {
                     method_not_allowed()
                 }
+                _ if path.matched(paths::ID_SESSIONS_SESSION_ID_EXECUTE) => method_not_allowed(),
                 _ if path.matched(paths::ID_SESSIONS_SESSION_ID_INTERRUPT) => method_not_allowed(),
                 _ if path.matched(paths::ID_SESSIONS_SESSION_ID_KILL) => method_not_allowed(),
                 _ if path.matched(paths::ID_SESSIONS_SESSION_ID_RESTART) => method_not_allowed(),
@@ -1733,6 +1901,10 @@ impl<T> RequestParser<T> for ApiRequestParser {
             // DeleteSession - DELETE /sessions/{session_id}
             hyper::Method::DELETE if path.matched(paths::ID_SESSIONS_SESSION_ID) => {
                 Some("DeleteSession")
+            }
+            // ExecuteCode - POST /sessions/{session_id}/execute
+            hyper::Method::POST if path.matched(paths::ID_SESSIONS_SESSION_ID_EXECUTE) => {
+                Some("ExecuteCode")
             }
             // GetSession - GET /sessions/{session_id}
             hyper::Method::GET if path.matched(paths::ID_SESSIONS_SESSION_ID) => Some("GetSession"),

--- a/crates/kcclient/src/main.rs
+++ b/crates/kcclient/src/main.rs
@@ -20,8 +20,8 @@ use futures::{future, stream, SinkExt, Stream};
 use kallichore_api::{models, Api, ApiNoContext, Client, ContextWrapperExt, ListSessionsResponse};
 use kallichore_api::{
     models::{RestartSession, ServerConfiguration},
-    DeleteSessionResponse, GetServerConfigurationResponse, InterruptSessionResponse,
-    NewSessionResponse, RestartSessionResponse, ServerStatusResponse,
+    DeleteSessionResponse, ExecuteCodeResponse, GetServerConfigurationResponse,
+    InterruptSessionResponse, NewSessionResponse, RestartSessionResponse, ServerStatusResponse,
     SetServerConfigurationResponse,
 };
 
@@ -137,6 +137,22 @@ enum Commands {
         /// running session will be used
         #[arg(short, long)]
         session_id: Option<String>,
+    },
+
+    /// Execute code via the HTTP RPC (no WebSocket)
+    Run {
+        /// The session to execute code in. Optional; if not provided, the first
+        /// running session will be used
+        #[arg(short, long)]
+        session_id: Option<String>,
+
+        /// The code to execute
+        #[arg(short, long)]
+        code: String,
+
+        /// Maximum seconds to wait for execution (omit for no timeout)
+        #[arg(short, long)]
+        timeout: Option<i32>,
     },
 
     /// Delete an exited session
@@ -565,6 +581,127 @@ fn main() {
                 .unwrap();
             rt.block_on(execute_request(ws_stream, code, wait));
         }
+        Some(Commands::Run {
+            session_id,
+            code,
+            timeout,
+        }) => {
+            let session_id = match session_id {
+                Some(session_id) => session_id,
+                None => {
+                    let result = rt.block_on(client.list_sessions());
+                    if let Ok(ListSessionsResponse::ListOfActiveSessions(sessions)) = result {
+                        if let Some(session) = sessions.sessions.first() {
+                            session.session_id.clone()
+                        } else {
+                            eprintln!("No sessions available to execute code");
+                            return;
+                        }
+                    } else {
+                        eprintln!("Failed to list sessions");
+                        return;
+                    }
+                }
+            };
+            let mut request = models::ExecuteRequest::new(code);
+            request.timeout_seconds = timeout;
+            log::info!("Executing code in session '{}' via RPC", session_id);
+            match rt.block_on(client.execute_code(session_id.clone(), request)) {
+                Ok(resp) => match resp {
+                    ExecuteCodeResponse::ExecutionCompleted(reply) => {
+                        // Print all output messages in order
+                        for output in &reply.output {
+                            match output.r#type {
+                                models::ExecuteOutputType::Stream => {
+                                    let name = output
+                                        .stream_name
+                                        .as_deref()
+                                        .unwrap_or("stdout");
+                                    let text = output.text.as_deref().unwrap_or("");
+                                    if name == "stderr" {
+                                        eprint!("{}", text);
+                                    } else {
+                                        print!("{}", text);
+                                    }
+                                }
+                                models::ExecuteOutputType::DisplayData => {
+                                    if let Some(data) = &output.data {
+                                        for (mime, content) in data {
+                                            println!("--- display_data ({}) ---", mime);
+                                            println!("{}", content);
+                                        }
+                                    }
+                                }
+                                models::ExecuteOutputType::Error => {
+                                    if let Some(name) = &output.error_name {
+                                        eprint!("{}", name);
+                                        if let Some(msg) = &output.error_message {
+                                            eprint!(": {}", msg);
+                                        }
+                                        eprintln!();
+                                    }
+                                    if let Some(tb) = &output.error_traceback {
+                                        for line in tb {
+                                            eprintln!("{}", line);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Print the execution result if present
+                        if let Some(data) = &reply.data {
+                            for (mime, content) in data {
+                                println!("--- result ({}) ---", mime);
+                                println!("{}", content);
+                            }
+                        }
+
+                        // Print error info if the execution failed
+                        if reply.status == models::ExecuteReplyStatus::Error {
+                            if let Some(name) = &reply.error_name {
+                                eprint!("Error: {}", name);
+                                if let Some(msg) = &reply.error_message {
+                                    eprint!(": {}", msg);
+                                }
+                                eprintln!();
+                            }
+                            if let Some(tb) = &reply.error_traceback {
+                                for line in tb {
+                                    eprintln!("{}", line);
+                                }
+                            }
+                        }
+
+                        println!(
+                            "[execution_count: {}, status: {:?}]",
+                            reply.execution_count, reply.status
+                        );
+                    }
+                    ExecuteCodeResponse::InvalidRequest(error) => {
+                        eprintln!(
+                            "Invalid request: {}",
+                            serde_json::to_string_pretty(&error).unwrap()
+                        );
+                    }
+                    ExecuteCodeResponse::Unauthorized => {
+                        eprintln!("Access token is missing or invalid");
+                    }
+                    ExecuteCodeResponse::SessionNotFound => {
+                        eprintln!("Session '{}' not found", session_id);
+                    }
+                    ExecuteCodeResponse::ExecutionTimedOut(error) => {
+                        eprintln!(
+                            "Execution timed out: {}",
+                            serde_json::to_string_pretty(&error).unwrap()
+                        );
+                    }
+                },
+                Err(e) => {
+                    eprintln!("Failed to execute code: {:?}", e);
+                }
+            }
+        }
         Some(Commands::Kill { session_id }) => {
             let session_id = match session_id {
                 Some(session_id) => session_id,
@@ -732,6 +869,7 @@ fn main() {
             // Create the server configuration with the new idle timeout hours
             let config = ServerConfiguration {
                 idle_shutdown_hours: Some(hours),
+                resource_sample_interval_ms: None,
                 log_level: None,
             };
 

--- a/crates/kcserver/src/kernel_session/shell_wrapper.rs
+++ b/crates/kcserver/src/kernel_session/shell_wrapper.rs
@@ -72,7 +72,7 @@ impl ShellCommandBuilder {
     pub fn build_command(
         &self,
         argv: &[String],
-        resolved_env: &HashMap<String, String>,
+        #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] resolved_env: &HashMap<String, String>,
     ) -> Result<Option<ShellCommandInfo>, StartupError> {
         match self.startup_env {
             models::StartupEnvironment::None => Ok(None),

--- a/crates/kcserver/src/kernel_state.rs
+++ b/crates/kcserver/src/kernel_state.rs
@@ -11,9 +11,11 @@ use std::collections::HashMap;
 use async_channel::Sender;
 use kallichore_api::models;
 use kcshared::{
+    jupyter_message::JupyterMessage,
     kernel_message::{KernelMessage, StatusUpdate},
     websocket_message::WebsocketMessage,
 };
+use tokio::sync::mpsc;
 
 use crate::connection_file::ConnectionFile;
 use crate::execution_queue::ExecutionQueue;
@@ -68,7 +70,7 @@ pub struct KernelState {
     pub busy_since: Option<std::time::Instant>,
 
     /// A channel on which to send idle nudges
-    pub idle_nudge_tx: tokio::sync::mpsc::Sender<Option<u32>>,
+    pub idle_nudge_tx: mpsc::Sender<Option<u32>>,
 
     /// A channel to publish status updates to the websocket
     ws_json_tx: Sender<WebsocketMessage>,
@@ -84,6 +86,12 @@ pub struct KernelState {
 
     /// The most recent resource usage measurement for the kernel.
     pub resource_usage: Option<models::ResourceUsage>,
+
+    /// RPC listeners: maps a parent msg_id to a channel that receives
+    /// Jupyter messages matching that parent. Used by the execute_code RPC
+    /// to collect iopub output and the shell reply without going through
+    /// the WebSocket.
+    pub rpc_listeners: HashMap<String, mpsc::UnboundedSender<JupyterMessage>>,
 }
 
 impl KernelState {
@@ -91,7 +99,7 @@ impl KernelState {
     pub fn new(
         session: models::NewSession,
         working_directory: String,
-        idle_nudge_tx: tokio::sync::mpsc::Sender<Option<u32>>,
+        idle_nudge_tx: mpsc::Sender<Option<u32>>,
         ws_json_tx: Sender<WebsocketMessage>,
     ) -> Self {
         KernelState {
@@ -114,6 +122,7 @@ impl KernelState {
             client_socket_path: None,
             kernel_info: None,
             resource_usage: None,
+            rpc_listeners: HashMap::new(),
         }
     }
 

--- a/crates/kcserver/src/server.rs
+++ b/crates/kcserver/src/server.rs
@@ -74,14 +74,18 @@ use crate::working_dir;
 use crate::zmq_ws_proxy::{self, ZmqWsProxy};
 use kallichore_api::{
     models, AdoptSessionResponse, ChannelsUpgradeResponse, ConnectionInfoResponse,
-    DeleteSessionResponse, GetSessionResponse, InterruptSessionResponse, KillSessionResponse,
-    NewSessionResponse, RestartSessionResponse, ShutdownServerResponse, StartSessionResponse,
+    DeleteSessionResponse, ExecuteCodeResponse, GetSessionResponse, InterruptSessionResponse,
+    KillSessionResponse, NewSessionResponse, RestartSessionResponse, ShutdownServerResponse,
+    StartSessionResponse,
 };
 use kcshared::{
     handshake_protocol::{HandshakeStatus, HandshakeVersion},
+    jupyter_message::{JupyterChannel, JupyterMessage, JupyterMessageHeader},
     kernel_message::KernelMessage,
     websocket_message::WebsocketMessage,
 };
+
+use crate::kernel_session::make_message_id;
 use tokio::sync::broadcast;
 
 // Enum to handle different listener types in server
@@ -1103,6 +1107,177 @@ impl<C> Server<C> {
         // If we got here, the token is valid or not required
         return true;
     }
+
+    /// Collect execution output from the RPC listener channel until the
+    /// execute_reply arrives on the shell channel.
+    async fn collect_execution_output(
+        rpc_rx: &mut mpsc::UnboundedReceiver<JupyterMessage>,
+        msg_id: &str,
+        timeout_duration: Option<std::time::Duration>,
+    ) -> Result<models::ExecuteReply, ExecuteCodeError> {
+        let mut output: Vec<models::ExecuteOutput> = Vec::new();
+        let mut data: Option<std::collections::HashMap<String, String>> = None;
+        #[allow(unused_assignments)]
+        let mut status = models::ExecuteReplyStatus::Ok;
+        #[allow(unused_assignments)]
+        let mut execution_count: i32 = 0;
+        let mut error_name: Option<String> = None;
+        let mut error_message: Option<String> = None;
+        let mut error_traceback: Option<Vec<String>> = None;
+
+        loop {
+            let msg = if let Some(duration) = timeout_duration {
+                match tokio::time::timeout(duration, rpc_rx.recv()).await {
+                    Ok(Some(msg)) => msg,
+                    Ok(None) => return Err(ExecuteCodeError::ChannelClosed),
+                    Err(_) => return Err(ExecuteCodeError::Timeout),
+                }
+            } else {
+                match rpc_rx.recv().await {
+                    Some(msg) => msg,
+                    None => return Err(ExecuteCodeError::ChannelClosed),
+                }
+            };
+
+            let msg_type = msg.header.msg_type.as_str();
+            log::trace!(
+                "execute_code RPC received message type '{}' for msg_id '{}'",
+                msg_type,
+                msg_id,
+            );
+
+            match msg_type {
+                "stream" => {
+                    let mut entry = models::ExecuteOutput::new(models::ExecuteOutputType::Stream);
+                    entry.stream_name = msg
+                        .content
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    entry.text = msg
+                        .content
+                        .get("text")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    output.push(entry);
+                }
+                "display_data" => {
+                    let mut entry =
+                        models::ExecuteOutput::new(models::ExecuteOutputType::DisplayData);
+                    entry.data = msg.content.get("data").and_then(|v| {
+                        v.as_object().map(|obj| {
+                            obj.iter()
+                                .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                                .collect()
+                        })
+                    });
+                    entry.metadata = msg.content.get("metadata").cloned();
+                    output.push(entry);
+                }
+                "error" => {
+                    let mut entry = models::ExecuteOutput::new(models::ExecuteOutputType::Error);
+                    entry.error_name = msg
+                        .content
+                        .get("ename")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    entry.error_message = msg
+                        .content
+                        .get("evalue")
+                        .and_then(|v| v.as_str())
+                        .map(String::from);
+                    entry.error_traceback = msg.content.get("traceback").and_then(|v| {
+                        v.as_array()
+                            .map(|arr| arr.iter().filter_map(|s| s.as_str().map(String::from)).collect())
+                    });
+                    output.push(entry);
+                }
+                "execute_result" => {
+                    // Hoist into the top-level `data` field of ExecuteReply
+                    data = msg.content.get("data").and_then(|v| {
+                        v.as_object().map(|obj| {
+                            obj.iter()
+                                .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                                .collect()
+                        })
+                    });
+                    execution_count = msg
+                        .content
+                        .get("execution_count")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0) as i32;
+                }
+                "execute_reply" => {
+                    // This is the shell reply that signals execution is complete
+                    let reply_status = msg
+                        .content
+                        .get("status")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("ok");
+                    status = if reply_status == "error" {
+                        models::ExecuteReplyStatus::Error
+                    } else {
+                        models::ExecuteReplyStatus::Ok
+                    };
+                    execution_count = msg
+                        .content
+                        .get("execution_count")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(execution_count as i64)
+                        as i32;
+
+                    // Extract error info from the reply itself if present
+                    if reply_status == "error" {
+                        error_name = msg
+                            .content
+                            .get("ename")
+                            .and_then(|v| v.as_str())
+                            .map(String::from);
+                        error_message = msg
+                            .content
+                            .get("evalue")
+                            .and_then(|v| v.as_str())
+                            .map(String::from);
+                        error_traceback =
+                            msg.content.get("traceback").and_then(|v| {
+                                v.as_array().map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|s| s.as_str().map(String::from))
+                                        .collect()
+                                })
+                            });
+                    }
+
+                    // Done — execution is complete
+                    break;
+                }
+                "status" => {
+                    // Ignore status messages (busy/idle)
+                }
+                other => {
+                    log::debug!(
+                        "execute_code RPC ignoring unexpected message type '{}' for msg_id '{}'",
+                        other,
+                        msg_id,
+                    );
+                }
+            }
+        }
+
+        let mut reply = models::ExecuteReply::new(status, execution_count, output);
+        reply.data = data;
+        reply.error_name = error_name;
+        reply.error_message = error_message;
+        reply.error_traceback = error_traceback;
+
+        Ok(reply)
+    }
+}
+
+/// Errors that can occur during execute_code collection
+enum ExecuteCodeError {
+    Timeout,
+    ChannelClosed,
 }
 
 #[async_trait]
@@ -1617,6 +1792,126 @@ where
             Err(e) => Ok(StartSessionResponse::StartFailed(e)),
         }
     }
+
+    async fn execute_code(
+        &self,
+        session_id: String,
+        execute_request: models::ExecuteRequest,
+        context: &C,
+    ) -> Result<ExecuteCodeResponse, ApiError> {
+        let ctx_span: &dyn Has<XSpanIdString> = context;
+        info!(
+            "execute_code(\"{}\") - X-Span-ID: {:?}",
+            session_id,
+            ctx_span.get().0.clone(),
+        );
+
+        // Token validation
+        if !self.validate_token(context) {
+            return Ok(ExecuteCodeResponse::Unauthorized);
+        }
+
+        let kernel_session = match self.find_session(session_id.clone()) {
+            Some(kernel_session) => kernel_session,
+            None => {
+                return Ok(ExecuteCodeResponse::SessionNotFound);
+            }
+        };
+
+        // Verify the session is in a runnable state
+        {
+            let state = kernel_session.state.read().await;
+            match state.status {
+                models::Status::Idle | models::Status::Busy => {}
+                _ => {
+                    return Ok(ExecuteCodeResponse::InvalidRequest(models::Error {
+                        code: "session_not_ready".to_string(),
+                        message: format!(
+                            "Session is in '{}' state; must be idle or busy to execute code",
+                            state.status
+                        ),
+                        details: None,
+                    }));
+                }
+            }
+        }
+
+        // Create the execute_request Jupyter message
+        let msg_id = make_message_id();
+        let jupyter_msg = JupyterMessage {
+            header: JupyterMessageHeader {
+                msg_id: msg_id.clone(),
+                msg_type: "execute_request".to_string(),
+            },
+            parent_header: None,
+            channel: JupyterChannel::Shell,
+            content: serde_json::json!({
+                "code": execute_request.code,
+                "silent": execute_request.silent.unwrap_or(false),
+                "store_history": execute_request.store_history.unwrap_or(true),
+                "user_expressions": {},
+                "allow_stdin": false,
+                "stop_on_error": execute_request.stop_on_error.unwrap_or(true),
+            }),
+            metadata: serde_json::json!({}),
+            buffers: vec![],
+        };
+
+        // Register an RPC listener for this msg_id
+        let (rpc_tx, mut rpc_rx) = mpsc::unbounded_channel::<JupyterMessage>();
+        {
+            let mut state = kernel_session.state.write().await;
+            state.rpc_listeners.insert(msg_id.clone(), rpc_tx);
+        }
+
+        // Send the message through the same path as WebSocket executions,
+        // which routes through the execution queue in the ZMQ proxy
+        if let Err(e) = kernel_session.ws_zmq_tx.send(jupyter_msg).await {
+            // Clean up the listener
+            let mut state = kernel_session.state.write().await;
+            state.rpc_listeners.remove(&msg_id);
+            return Ok(ExecuteCodeResponse::InvalidRequest(models::Error {
+                code: "send_failed".to_string(),
+                message: format!("Failed to send execute request to kernel: {}", e),
+                details: None,
+            }));
+        }
+
+        // Collect output messages until we receive the execute_reply
+        let timeout_duration = execute_request
+            .timeout_seconds
+            .map(|s| std::time::Duration::from_secs(s as u64));
+
+        let result = Self::collect_execution_output(&mut rpc_rx, &msg_id, timeout_duration).await;
+
+        // Unregister the RPC listener
+        {
+            let mut state = kernel_session.state.write().await;
+            state.rpc_listeners.remove(&msg_id);
+        }
+
+        match result {
+            Ok(reply) => Ok(ExecuteCodeResponse::ExecutionCompleted(reply)),
+            Err(ExecuteCodeError::Timeout) => {
+                Ok(ExecuteCodeResponse::ExecutionTimedOut(models::Error {
+                    code: "timeout".to_string(),
+                    message: format!(
+                        "Execution timed out after {} seconds",
+                        execute_request.timeout_seconds.unwrap_or(0)
+                    ),
+                    details: None,
+                }))
+            }
+            Err(ExecuteCodeError::ChannelClosed) => {
+                Ok(ExecuteCodeResponse::InvalidRequest(models::Error {
+                    code: "channel_closed".to_string(),
+                    message: "Kernel message channel closed unexpectedly".to_string(),
+                    details: None,
+                }))
+            }
+        }
+    }
+
 
     async fn interrupt_session(
         &self,

--- a/crates/kcserver/src/server.rs
+++ b/crates/kcserver/src/server.rs
@@ -1125,6 +1125,12 @@ impl<C> Server<C> {
         let mut error_message: Option<String> = None;
         let mut error_traceback: Option<Vec<String>> = None;
 
+        // We need both execute_reply (shell) and status:idle (IOPub) before
+        // returning, because ZMQ delivers them over different sockets and the
+        // execute_result on IOPub may arrive after execute_reply on shell.
+        let mut got_execute_reply = false;
+        let mut got_idle = false;
+
         // Use an absolute deadline so the timeout covers total execution time,
         // not each individual message receive.
         let deadline = timeout_duration.map(|d| tokio::time::Instant::now() + d);
@@ -1220,7 +1226,7 @@ impl<C> Server<C> {
                         .unwrap_or(0) as i32;
                 }
                 "execute_reply" => {
-                    // This is the shell reply that signals execution is complete
+                    // This is the shell reply that signals execution is complete.
                     let reply_status = msg
                         .content
                         .get("status")
@@ -1260,11 +1266,23 @@ impl<C> Server<C> {
                             });
                     }
 
-                    // Done — execution is complete
-                    break;
+                    got_execute_reply = true;
+                    if got_idle {
+                        break;
+                    }
                 }
                 "status" => {
-                    // Ignore status messages (busy/idle)
+                    let is_idle = msg
+                        .content
+                        .get("execution_state")
+                        .and_then(|v| v.as_str())
+                        == Some("idle");
+                    if is_idle {
+                        got_idle = true;
+                        if got_execute_reply {
+                            break;
+                        }
+                    }
                 }
                 other => {
                     log::debug!(

--- a/crates/kcserver/src/server.rs
+++ b/crates/kcserver/src/server.rs
@@ -1910,6 +1910,7 @@ where
         // Collect output messages until we receive the execute_reply
         let timeout_duration = execute_request
             .timeout_seconds
+            .filter(|&s| s > 0)
             .map(|s| std::time::Duration::from_secs(s as u64));
 
         let result = Self::collect_execution_output(&mut rpc_rx, &msg_id, timeout_duration).await;

--- a/crates/kcserver/src/server.rs
+++ b/crates/kcserver/src/server.rs
@@ -1125,9 +1125,13 @@ impl<C> Server<C> {
         let mut error_message: Option<String> = None;
         let mut error_traceback: Option<Vec<String>> = None;
 
+        // Use an absolute deadline so the timeout covers total execution time,
+        // not each individual message receive.
+        let deadline = timeout_duration.map(|d| tokio::time::Instant::now() + d);
+
         loop {
-            let msg = if let Some(duration) = timeout_duration {
-                match tokio::time::timeout(duration, rpc_rx.recv()).await {
+            let msg = if let Some(deadline) = deadline {
+                match tokio::time::timeout_at(deadline, rpc_rx.recv()).await {
                     Ok(Some(msg)) => msg,
                     Ok(None) => return Err(ExecuteCodeError::ChannelClosed),
                     Err(_) => return Err(ExecuteCodeError::Timeout),
@@ -1167,7 +1171,11 @@ impl<C> Server<C> {
                     entry.data = msg.content.get("data").and_then(|v| {
                         v.as_object().map(|obj| {
                             obj.iter()
-                                .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                                .map(|(k, v)| {
+                                    let s = v.as_str().map(String::from)
+                                        .unwrap_or_else(|| v.to_string());
+                                    (k.clone(), s)
+                                })
                                 .collect()
                         })
                     });
@@ -1197,7 +1205,11 @@ impl<C> Server<C> {
                     data = msg.content.get("data").and_then(|v| {
                         v.as_object().map(|obj| {
                             obj.iter()
-                                .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                                .map(|(k, v)| {
+                                    let s = v.as_str().map(String::from)
+                                        .unwrap_or_else(|| v.to_string());
+                                    (k.clone(), s)
+                                })
                                 .collect()
                         })
                     });
@@ -1893,6 +1905,13 @@ where
         match result {
             Ok(reply) => Ok(ExecuteCodeResponse::ExecutionCompleted(reply)),
             Err(ExecuteCodeError::Timeout) => {
+                // Interrupt the kernel so timed-out code stops consuming resources
+                if let Err(e) = kernel_session.interrupt().await {
+                    log::warn!(
+                        "Failed to interrupt kernel after execution timeout: {}",
+                        e
+                    );
+                }
                 Ok(ExecuteCodeResponse::ExecutionTimedOut(models::Error {
                     code: "timeout".to_string(),
                     message: format!(

--- a/crates/kcserver/src/zmq_ws_proxy.rs
+++ b/crates/kcserver/src/zmq_ws_proxy.rs
@@ -655,6 +655,23 @@ impl ZmqWsProxy {
             }
         }
 
+        // (2.5) If there's an RPC listener registered for this message's parent
+        // msg_id, forward a clone to it. This allows the execute_code RPC to
+        // collect output without interfering with the WebSocket stream.
+        if let Some(ref parent_header) = message.parent_header {
+            let state = self.state.read().await;
+            if let Some(rpc_tx) = state.rpc_listeners.get(&parent_header.msg_id) {
+                if let Err(e) = rpc_tx.send(message.clone()) {
+                    log::warn!(
+                        "[session {}] Failed to forward message to RPC listener for {}: {}",
+                        self.session_id,
+                        parent_header.msg_id,
+                        e
+                    );
+                }
+            }
+        }
+
         // (3) wrap the Jupyter message in a `WebsocketMessage::Jupyter` and send it
         // to the WebSocket.
         let message = WebsocketMessage::Jupyter(message);

--- a/crates/kcserver/tests/execute_code_test.rs
+++ b/crates/kcserver/tests/execute_code_test.rs
@@ -1,0 +1,388 @@
+//
+// execute_code_test.rs
+//
+// Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+//
+
+//! Integration tests for the execute_code RPC endpoint
+//!
+//! These tests verify that code can be executed via the HTTP RPC without
+//! needing a WebSocket connection.
+
+#![allow(unused_imports)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::test_utils::{
+    create_session_with_client, create_test_session, get_python_executable, is_ipykernel_available,
+};
+use common::TestServer;
+use kallichore_api::models::{ExecuteReplyStatus, ExecuteRequest, Status};
+use kallichore_api::{ExecuteCodeResponse, GetSessionResponse, StartSessionResponse};
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Helper: create a session, start it, and return the session_id
+async fn setup_kernel_session(
+    server: &TestServer,
+    python_cmd: &str,
+) -> (
+    Box<dyn kallichore_api::ApiNoContext<common::test_utils::ClientContext> + Send + Sync>,
+    String,
+) {
+    let client = server.create_client().await;
+    let session_id = format!("test-exec-{}", Uuid::new_v4());
+    let new_session = create_test_session(session_id.clone(), python_cmd);
+
+    create_session_with_client(&client, new_session).await;
+
+    let start_response = client
+        .start_session(session_id.clone())
+        .await
+        .expect("Failed to start session");
+
+    match start_response {
+        StartSessionResponse::Started(_) => {
+            println!("Kernel started for session {}", session_id);
+        }
+        other => panic!("Unexpected start response: {:?}", other),
+    }
+
+    // Wait for the kernel to become idle (ready to execute)
+    for _ in 0..60 {
+        let session_response = client
+            .get_session(session_id.clone())
+            .await
+            .expect("Failed to get session");
+        if let GetSessionResponse::SessionDetails(details) = session_response {
+            if details.status == Status::Idle {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    (client, session_id)
+}
+
+#[tokio::test]
+async fn test_execute_code_basic() {
+    let test_result = tokio::time::timeout(Duration::from_secs(30), async {
+        let python_cmd = match get_python_executable().await {
+            Some(cmd) => cmd,
+            None => {
+                println!("Skipping: No Python executable found");
+                return;
+            }
+        };
+        if !is_ipykernel_available().await {
+            println!("Skipping: ipykernel not available");
+            return;
+        }
+
+        let server = TestServer::start().await;
+        let (client, session_id) = setup_kernel_session(&server, &python_cmd).await;
+
+        // Execute simple print statement
+        let request = ExecuteRequest::new("print('hello world')".to_string());
+        let response = client
+            .execute_code(session_id.clone(), request)
+            .await
+            .expect("Failed to call execute_code");
+
+        match response {
+            ExecuteCodeResponse::ExecutionCompleted(reply) => {
+                println!("Execute reply: {:?}", reply);
+                assert_eq!(reply.status, ExecuteReplyStatus::Ok);
+                assert!(reply.execution_count >= 1);
+
+                // Check that stdout was captured
+                let stdout: String = reply
+                    .output
+                    .iter()
+                    .filter(|o| o.stream_name.as_deref() == Some("stdout"))
+                    .filter_map(|o| o.text.as_deref())
+                    .collect();
+                assert!(
+                    stdout.contains("hello world"),
+                    "Expected 'hello world' in stdout, got: {:?}",
+                    stdout
+                );
+            }
+            other => panic!("Expected ExecutionCompleted, got: {:?}", other),
+        }
+    })
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test]
+async fn test_execute_code_with_result() {
+    let test_result = tokio::time::timeout(Duration::from_secs(30), async {
+        let python_cmd = match get_python_executable().await {
+            Some(cmd) => cmd,
+            None => {
+                println!("Skipping: No Python executable found");
+                return;
+            }
+        };
+        if !is_ipykernel_available().await {
+            println!("Skipping: ipykernel not available");
+            return;
+        }
+
+        let server = TestServer::start().await;
+        let (client, session_id) = setup_kernel_session(&server, &python_cmd).await;
+
+        // Execute an expression that produces a result
+        let request = ExecuteRequest::new("2 + 3".to_string());
+        let response = client
+            .execute_code(session_id.clone(), request)
+            .await
+            .expect("Failed to call execute_code");
+
+        match response {
+            ExecuteCodeResponse::ExecutionCompleted(reply) => {
+                println!("Execute reply: {:?}", reply);
+                assert_eq!(reply.status, ExecuteReplyStatus::Ok);
+
+                // The result should be hoisted into the top-level data field
+                assert!(reply.data.is_some(), "Expected data field to be set");
+                let data = reply.data.unwrap();
+                let text_plain = data.get("text/plain").expect("Expected text/plain in data");
+                assert_eq!(text_plain, "5");
+            }
+            other => panic!("Expected ExecutionCompleted, got: {:?}", other),
+        }
+    })
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test]
+async fn test_execute_code_error() {
+    let test_result = tokio::time::timeout(Duration::from_secs(30), async {
+        let python_cmd = match get_python_executable().await {
+            Some(cmd) => cmd,
+            None => {
+                println!("Skipping: No Python executable found");
+                return;
+            }
+        };
+        if !is_ipykernel_available().await {
+            println!("Skipping: ipykernel not available");
+            return;
+        }
+
+        let server = TestServer::start().await;
+        let (client, session_id) = setup_kernel_session(&server, &python_cmd).await;
+
+        // Execute code that raises an error
+        let request = ExecuteRequest::new("raise ValueError('test error')".to_string());
+        let response = client
+            .execute_code(session_id.clone(), request)
+            .await
+            .expect("Failed to call execute_code");
+
+        match response {
+            ExecuteCodeResponse::ExecutionCompleted(reply) => {
+                println!("Execute reply: {:?}", reply);
+                assert_eq!(reply.status, ExecuteReplyStatus::Error);
+                assert_eq!(reply.error_name.as_deref(), Some("ValueError"));
+                assert_eq!(reply.error_message.as_deref(), Some("test error"));
+                assert!(reply.error_traceback.is_some());
+
+                // The error should also appear in the output array
+                let error_outputs: Vec<_> = reply
+                    .output
+                    .iter()
+                    .filter(|o| {
+                        o.r#type == kallichore_api::models::ExecuteOutputType::Error
+                    })
+                    .collect();
+                assert!(
+                    !error_outputs.is_empty(),
+                    "Expected error output in the output array"
+                );
+            }
+            other => panic!("Expected ExecutionCompleted, got: {:?}", other),
+        }
+    })
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test]
+async fn test_execute_code_sequential() {
+    let test_result = tokio::time::timeout(Duration::from_secs(30), async {
+        let python_cmd = match get_python_executable().await {
+            Some(cmd) => cmd,
+            None => {
+                println!("Skipping: No Python executable found");
+                return;
+            }
+        };
+        if !is_ipykernel_available().await {
+            println!("Skipping: ipykernel not available");
+            return;
+        }
+
+        let server = TestServer::start().await;
+        let (client, session_id) = setup_kernel_session(&server, &python_cmd).await;
+
+        // First execution: set a variable
+        let request = ExecuteRequest::new("x = 42".to_string());
+        let response = client
+            .execute_code(session_id.clone(), request)
+            .await
+            .expect("Failed to call execute_code");
+        match &response {
+            ExecuteCodeResponse::ExecutionCompleted(reply) => {
+                assert_eq!(reply.status, ExecuteReplyStatus::Ok);
+            }
+            other => panic!("Expected ExecutionCompleted, got: {:?}", other),
+        }
+
+        // Second execution: use the variable
+        let request = ExecuteRequest::new("print(x * 2)".to_string());
+        let response = client
+            .execute_code(session_id.clone(), request)
+            .await
+            .expect("Failed to call execute_code");
+        match response {
+            ExecuteCodeResponse::ExecutionCompleted(reply) => {
+                assert_eq!(reply.status, ExecuteReplyStatus::Ok);
+
+                let stdout: String = reply
+                    .output
+                    .iter()
+                    .filter(|o| o.stream_name.as_deref() == Some("stdout"))
+                    .filter_map(|o| o.text.as_deref())
+                    .collect();
+                assert!(
+                    stdout.contains("84"),
+                    "Expected '84' in stdout, got: {:?}",
+                    stdout
+                );
+            }
+            other => panic!("Expected ExecutionCompleted, got: {:?}", other),
+        }
+    })
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test]
+async fn test_execute_code_timeout() {
+    let test_result = tokio::time::timeout(Duration::from_secs(30), async {
+        let python_cmd = match get_python_executable().await {
+            Some(cmd) => cmd,
+            None => {
+                println!("Skipping: No Python executable found");
+                return;
+            }
+        };
+        if !is_ipykernel_available().await {
+            println!("Skipping: ipykernel not available");
+            return;
+        }
+
+        let server = TestServer::start().await;
+        let (client, session_id) = setup_kernel_session(&server, &python_cmd).await;
+
+        // Execute code that takes longer than the timeout
+        let mut request =
+            ExecuteRequest::new("import time; time.sleep(10)".to_string());
+        request.timeout_seconds = Some(1);
+        let response = client
+            .execute_code(session_id.clone(), request)
+            .await
+            .expect("Failed to call execute_code");
+
+        match response {
+            ExecuteCodeResponse::ExecutionTimedOut(err) => {
+                println!("Got expected timeout: {:?}", err);
+                assert_eq!(err.code, "timeout");
+            }
+            other => panic!("Expected ExecutionTimedOut, got: {:?}", other),
+        }
+    })
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test]
+async fn test_execute_code_session_not_found() {
+    let test_result = tokio::time::timeout(Duration::from_secs(15), async {
+        let server = TestServer::start().await;
+        let client = server.create_client().await;
+
+        let request = ExecuteRequest::new("print('hello')".to_string());
+        let response = client
+            .execute_code("nonexistent-session".to_string(), request)
+            .await
+            .expect("Failed to call execute_code");
+
+        match response {
+            ExecuteCodeResponse::SessionNotFound => {
+                println!("Got expected SessionNotFound");
+            }
+            other => panic!("Expected SessionNotFound, got: {:?}", other),
+        }
+    })
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}
+
+#[tokio::test]
+async fn test_execute_code_silent() {
+    let test_result = tokio::time::timeout(Duration::from_secs(30), async {
+        let python_cmd = match get_python_executable().await {
+            Some(cmd) => cmd,
+            None => {
+                println!("Skipping: No Python executable found");
+                return;
+            }
+        };
+        if !is_ipykernel_available().await {
+            println!("Skipping: ipykernel not available");
+            return;
+        }
+
+        let server = TestServer::start().await;
+        let (client, session_id) = setup_kernel_session(&server, &python_cmd).await;
+
+        // Execute silently - should not produce an execute_result
+        let mut request = ExecuteRequest::new("2 + 3".to_string());
+        request.silent = Some(true);
+        let response = client
+            .execute_code(session_id.clone(), request)
+            .await
+            .expect("Failed to call execute_code");
+
+        match response {
+            ExecuteCodeResponse::ExecutionCompleted(reply) => {
+                println!("Silent execute reply: {:?}", reply);
+                assert_eq!(reply.status, ExecuteReplyStatus::Ok);
+                // In silent mode, execution_count should not increment
+                // and there should be no execute_result data
+                assert!(
+                    reply.data.is_none(),
+                    "Silent execution should not produce result data"
+                );
+            }
+            other => panic!("Expected ExecutionCompleted, got: {:?}", other),
+        }
+    })
+    .await;
+
+    assert!(test_result.is_ok(), "Test timed out");
+}

--- a/kallichore.json
+++ b/kallichore.json
@@ -531,6 +531,76 @@
         }
       }
     },
+    "/sessions/{session_id}/execute": {
+      "post": {
+        "operationId": "execute-code",
+        "summary": "Execute code and return results",
+        "security": [
+          "bearerAuth"
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/executeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Execution completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/executeReply"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "404": {
+            "description": "Session not found",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "408": {
+            "description": "Execution timed out",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/shutdown": {
       "post": {
         "operationId": "shutdown-server",
@@ -982,6 +1052,142 @@
         "required": [
           "length",
           "pending"
+        ]
+      },
+      "executeRequest": {
+        "type": "object",
+        "description": "A request to execute code in a session",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "The code to execute"
+          },
+          "silent": {
+            "type": "boolean",
+            "description": "If true, signals the kernel to execute quietly: no broadcast on iopub, no execute_result, and the execution_count is not incremented. Defaults to false.",
+            "default": false
+          },
+          "store_history": {
+            "type": "boolean",
+            "description": "If true (default), the code is stored in the kernel's history. Set to false for throwaway executions.",
+            "default": true
+          },
+          "stop_on_error": {
+            "type": "boolean",
+            "description": "If true (default), abort the execution queue on error. If false, queued execute requests will still be processed even if this one fails.",
+            "default": true
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "description": "Maximum number of seconds to wait for execution to complete. If not specified, the request will block indefinitely until execution finishes."
+          }
+        },
+        "required": [
+          "code"
+        ]
+      },
+      "executeReply": {
+        "type": "object",
+        "description": "The result of executing code in a session",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Whether the execution succeeded or errored",
+            "enum": [
+              "ok",
+              "error"
+            ]
+          },
+          "execution_count": {
+            "type": "integer",
+            "description": "The kernel's execution counter"
+          },
+          "output": {
+            "type": "array",
+            "description": "All output messages produced during execution, in order",
+            "items": {
+              "$ref": "#/components/schemas/executeOutput"
+            }
+          },
+          "data": {
+            "type": "object",
+            "description": "The execution result as a MIME-keyed dictionary (from execute_result), if the execution produced a result",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "error_name": {
+            "type": "string",
+            "description": "The error name, if the execution failed"
+          },
+          "error_message": {
+            "type": "string",
+            "description": "The error message, if the execution failed"
+          },
+          "error_traceback": {
+            "type": "array",
+            "description": "The error traceback, if the execution failed",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "status",
+          "execution_count",
+          "output"
+        ]
+      },
+      "executeOutput": {
+        "type": "object",
+        "description": "A single output message produced during code execution",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The output message type",
+            "enum": [
+              "stream",
+              "display_data",
+              "error"
+            ]
+          },
+          "stream_name": {
+            "type": "string",
+            "description": "The stream name (stdout or stderr), for stream output"
+          },
+          "text": {
+            "type": "string",
+            "description": "The text content, for stream output"
+          },
+          "data": {
+            "type": "object",
+            "description": "MIME-keyed data, for display_data output",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata dictionary, for display_data output"
+          },
+          "error_name": {
+            "type": "string",
+            "description": "The error name, for error output"
+          },
+          "error_message": {
+            "type": "string",
+            "description": "The error message, for error output"
+          },
+          "error_traceback": {
+            "type": "array",
+            "description": "The error traceback lines, for error output",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "type"
         ]
       },
       "activeSession": {

--- a/scripts/remove-tls-deps.sh
+++ b/scripts/remove-tls-deps.sh
@@ -317,40 +317,83 @@ def fix_server_example(filepath):
         content,
         flags=re.DOTALL
     )
-    
-    # Remove the entire `if https {` block
-    # This regex matches: `if https {` ... `}` (with proper brace matching)
+
+    # Fix the doc comment
+    content = content.replace(
+        '/// Builds an SSL implementation for Simple HTTPS from some hard-coded file names',
+        '/// Creates an HTTP server (HTTPS/TLS support removed)'
+    )
+
+    # Add #[allow(unused_variables)] to the https parameter
+    content = re.sub(
+        r'pub async fn create\(addr: &str, https: bool\)',
+        'pub async fn create(addr: &str, #[allow(unused_variables)] https: bool)',
+        content
+    )
+
+    # Remove the `if https { ... }` block while keeping the `else { ... }` body.
+    # The generator produces `if https { /* HTTPS */ } else { /* HTTP */ }`.
+    # We want to strip the HTTPS branch and the if/else wrapper, keeping the
+    # HTTP code from the else branch.
     lines = content.split('\n')
     output = []
     i = 0
     skip_https_block = False
+    in_else_block = False
     brace_depth = 0
-    
+
     while i < len(lines):
         line = lines[i]
-        
+
         # Start of https block
-        if re.match(r'^\s+if https \{', line):
+        if not skip_https_block and not in_else_block and re.match(r'^\s+if https \{', line):
             skip_https_block = True
             brace_depth = 1
             i += 1
             continue
-        
+
         if skip_https_block:
+            # Check for `} else {` transition before counting braces
+            if re.match(r'^\s*\}\s*else\s*\{', line.strip()) or re.match(r'^\s+\}\s*else\s*\{', line):
+                # Switch to keeping the else body
+                skip_https_block = False
+                in_else_block = True
+                brace_depth = 1
+                i += 1
+                continue
+
             # Count braces
             brace_depth += line.count('{')
             brace_depth -= line.count('}')
-            
+
             # If we've closed all braces, we're done skipping
             if brace_depth == 0:
                 skip_https_block = False
-            
+
             i += 1
             continue
-        
+
+        if in_else_block:
+            brace_depth += line.count('{')
+            brace_depth -= line.count('}')
+
+            if brace_depth == 0:
+                # This is the closing } of the else block; skip it
+                in_else_block = False
+                i += 1
+                continue
+
+            # Keep the line (dedent by 4 spaces if possible)
+            if line.startswith('            '):
+                output.append(line[4:])
+            else:
+                output.append(line)
+            i += 1
+            continue
+
         output.append(line)
         i += 1
-    
+
     with open(filepath, 'w') as f:
         f.write('\n'.join(output))
 


### PR DESCRIPTION
This change adds a code execution API to Kallichore. Prior to this change, you needed to open a websocket to execute code; now you can do so using nothing but the REST API. 

The new RPC accepts most of the same parameters as Jupyter's `execute_request` and returns the `execute_result` as `data` (along with all the other messages/data emitted during execution, such as stdout/stderr/display data/etc). 

This is intended to help support code executions from clients like MCPs and Quarto; it will not be used in ordinary Positron consoles/notebooks.

Fixes https://github.com/posit-dev/kallichore/issues/23.