### PR TITLE
Fix intermittent CI failure

### DIFF
--- a/crates/kcserver/src/kernel_session/startup.rs
+++ b/crates/kcserver/src/kernel_session/startup.rs
@@ -275,6 +275,28 @@ impl StartupCoordinator {
         {
             let mut state = self.state.write().await;
             state.set_kernel_info(kernel_info.clone());
+
+            // A successful kernel_info_reply means the kernel is alive and has
+            // finished handling a shell request, i.e. it's idle and ready to
+            // execute. Promote the status to Idle now rather than waiting for
+            // the kernel's startup `status: idle` message on iopub, which can
+            // be missed if the iopub SUB socket subscribes after the kernel
+            // emits it (a slow-joiner race that otherwise leaves the session
+            // stuck in 'starting'). Only promote from a startup state so we
+            // don't clobber a status the iopub stream may have already set.
+            if matches!(
+                state.status,
+                models::Status::Uninitialized
+                    | models::Status::Starting
+                    | models::Status::Ready
+            ) {
+                state
+                    .set_status(
+                        models::Status::Idle,
+                        Some(String::from("kernel_info_reply received")),
+                    )
+                    .await;
+            }
         }
 
         // Try to parse the kernel info to extract prompts

--- a/crates/kcserver/src/kernel_state.rs
+++ b/crates/kcserver/src/kernel_state.rs
@@ -207,6 +207,23 @@ impl KernelState {
             return;
         }
 
+        // Once the kernel has exited, don't let a late/buffered iopub status
+        // message (e.g. the trailing 'idle' a kernel emits while handling a
+        // shutdown_request) resurrect it into a running state. Coming back to
+        // life only happens via an explicit restart, which moves the status
+        // through 'starting' first.
+        if self.status == models::Status::Exited
+            && matches!(status, models::Status::Idle | models::Status::Busy)
+        {
+            log::debug!(
+                "[session {}] Ignoring status '{}' => '{}'; kernel has already exited",
+                self.session_id,
+                self.status,
+                status
+            );
+            return;
+        }
+
         self.status = status;
 
         // When exiting ...

--- a/crates/kcserver/src/server.rs
+++ b/crates/kcserver/src/server.rs
@@ -1848,20 +1848,50 @@ where
             }
         };
 
-        // Verify the session is in a runnable state
+        // Verify the session is in a runnable state. If the kernel is still
+        // coming up (uninitialized/starting/ready), wait for it to become
+        // ready rather than rejecting outright: callers commonly issue an
+        // execute_request immediately after start_session, before the kernel
+        // has published its first idle status on iopub.
         {
-            let state = kernel_session.state.read().await;
-            match state.status {
-                models::Status::Idle | models::Status::Busy => {}
-                _ => {
-                    return Ok(ExecuteCodeResponse::InvalidRequest(models::Error {
-                        code: "session_not_ready".to_string(),
-                        message: format!(
-                            "Session is in '{}' state; must be idle or busy to execute code",
-                            state.status
-                        ),
-                        details: None,
-                    }));
+            // How long to wait for a starting kernel to become ready before
+            // giving up.
+            const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+            const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+            let deadline = std::time::Instant::now() + READY_TIMEOUT;
+            loop {
+                let status = { kernel_session.state.read().await.status };
+                match status {
+                    // Runnable: proceed.
+                    models::Status::Idle | models::Status::Busy => break,
+                    // Still coming up: wait, unless we've run out of time.
+                    models::Status::Uninitialized
+                    | models::Status::Starting
+                    | models::Status::Ready => {
+                        if std::time::Instant::now() >= deadline {
+                            return Ok(ExecuteCodeResponse::InvalidRequest(models::Error {
+                                code: "session_not_ready".to_string(),
+                                message: format!(
+                                    "Session did not become ready within {:?} (last status: '{}')",
+                                    READY_TIMEOUT, status
+                                ),
+                                details: None,
+                            }));
+                        }
+                        tokio::time::sleep(POLL_INTERVAL).await;
+                    }
+                    // Not runnable and won't become runnable.
+                    models::Status::Offline | models::Status::Exited => {
+                        return Ok(ExecuteCodeResponse::InvalidRequest(models::Error {
+                            code: "session_not_ready".to_string(),
+                            message: format!(
+                                "Session is in '{}' state; must be idle or busy to execute code",
+                                status
+                            ),
+                            details: None,
+                        }));
+                    }
                 }
             }
         }

--- a/crates/kcserver/tests/execute_code_test.rs
+++ b/crates/kcserver/tests/execute_code_test.rs
@@ -50,19 +50,32 @@ async fn setup_kernel_session(
         other => panic!("Unexpected start response: {:?}", other),
     }
 
-    // Wait for the kernel to become idle (ready to execute)
-    for _ in 0..60 {
+    // Wait for the kernel to become ready (idle or busy) before returning.
+    // CI runners can be slow to spin up a kernel, so give this a generous
+    // budget and fail loudly if it never becomes ready; otherwise the
+    // caller executes code against a 'starting' session and can get a
+    // confusing `session_not_ready` error further down.
+    let mut last_status = None;
+    let mut ready = false;
+    for _ in 0..200 {
         let session_response = client
             .get_session(session_id.clone())
             .await
             .expect("Failed to get session");
         if let GetSessionResponse::SessionDetails(details) = session_response {
-            if details.status == Status::Idle {
+            last_status = Some(details.status);
+            if details.status == Status::Idle || details.status == Status::Busy {
+                ready = true;
                 break;
             }
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+    assert!(
+        ready,
+        "Kernel for session {} never became ready; last status: {:?}",
+        session_id, last_status
+    );
 
     (client, session_id)
 }

--- a/crates/kcserver/tests/python_kernel_tests.rs
+++ b/crates/kcserver/tests/python_kernel_tests.rs
@@ -1022,10 +1022,29 @@ async fn test_kernel_session_shutdown() {
     // Close the websocket connection
     comm.close().await.ok();
 
-    // Wait a bit more for the kernel process to fully exit
-    tokio::time::sleep(Duration::from_millis(1500)).await;
+    // Wait for the kernel to actually exit before deleting. delete_session
+    // refuses unless the session has reached the 'Exited' state, and process
+    // teardown can take a variable amount of time (notably slower on Windows
+    // CI), so poll rather than sleeping a fixed interval.
+    let exit_deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let details = client
+            .get_session(session_id.clone())
+            .await
+            .expect("Failed to get session while waiting for exit");
+        if let kallichore_api::GetSessionResponse::SessionDetails(d) = details {
+            if d.status == kallichore_api::models::Status::Exited {
+                break;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < exit_deadline,
+            "Kernel did not reach 'Exited' state within 15s after shutdown_request"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 
-    // Now we can delete the session since the kernel should have exited
+    // Now we can delete the session since the kernel has exited
     println!("Deleting kernel session...");
     let delete_response = client
         .delete_session(session_id.clone())


### PR DESCRIPTION
This change fixes a CI test failure that was happening ~50% of the time, e.g.:

```
---- test_execute_code_error stdout ----
ipykernel is available
error: test failed, to rerun pass `-p kcserver --test execute_code_test`
Using pre-built binary at: "/Users/runner/work/kallichore/kallichore/target/debug/kcserver"
Server ready after 1 attempts
Created session: NewSession200Response { session_id: "test-exec-3346c27a-1c7e-4d23-9303-bb3fe3fc7e2a" }
Kernel started for session test-exec-3346c27a-1c7e-4d23-9303-bb3fe3fc7e2a

thread 'test_execute_code_error' (14355) panicked at crates/kcserver/tests/execute_code_test.rs:212:22:
Expected ExecutionCompleted, got: InvalidRequest(Error { code: "session_not_ready", message: "Session is in 'starting' state; must be idle or busy to execute code", details: None })
```

The problem was that the tests were trying to call `execute_code` too soon after the kernel started up, so the `execute_code` RPC was racing against kernel startup. If a client called it right after `start_session` — before the kernel had published its first idle status — the request was rejected with `session_not_ready`. This showed up as an intermittent CI failure in the execute_code integration tests.

Now, if the session is still coming up (uninitialized/starting/ready), `execute_code` waits for it to become runnable rather than rejecting outright, up to a 30s deadline. Sessions that are offline or exited are still rejected immediately, since they won't become ready.

This fixes the race for all clients, not just the tests. I also hardened the test helper so that if a kernel somehow never becomes ready, it fails loudly with the last observed status instead of silently proceeding.
