### PR TITLE
Add a Server ID

### DIFF
--- a/crates/kallichore_api/README.md
+++ b/crates/kallichore_api/README.md
@@ -14,7 +14,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 1.0.0
-- Build date: 2026-04-08T15:56:17.963495-07:00[America/Los_Angeles]
+- Build date: 2026-06-23T15:49:56.724154-07:00[America/Los_Angeles]
 - Generator version: 7.17.0
 
 For more information, please visit [https://posit.co](https://posit.co)

--- a/crates/kallichore_api/api/openapi.yaml
+++ b/crates/kallichore_api/api/openapi.yaml
@@ -1033,6 +1033,7 @@ components:
         busy: true
         active: 6
         started: 2000-01-23T04:56:07.000+00:00
+        server_id: server_id
         version: version
         idle_seconds: 1
       properties:
@@ -1062,6 +1063,12 @@ components:
         started:
           description: An ISO 8601 timestamp of when the server was started
           format: date-time
+          type: string
+        server_id:
+          description: "A unique identifier generated when the server starts. Clients\
+            \ can compare this against a previously observed value to detect that\
+            \ they are talking to a different server instance (e.g. one that was restarted),\
+            \ and therefore that any persisted bearer token may be stale."
           type: string
       required:
       - active

--- a/crates/kallichore_api/docs/ServerStatus.md
+++ b/crates/kallichore_api/docs/ServerStatus.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **version** | **String** | The version of the server | 
 **process_id** | **i32** | The server's operating system process identifier | 
 **started** | [**chrono::DateTime::<chrono::Utc>**](DateTime.md) | An ISO 8601 timestamp of when the server was started | 
+**server_id** | **String** | A unique identifier generated when the server starts. Clients can compare this against a previously observed value to detect that they are talking to a different server instance (e.g. one that was restarted), and therefore that any persisted bearer token may be stale. | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/crates/kallichore_api/src/models.rs
+++ b/crates/kallichore_api/src/models.rs
@@ -4364,6 +4364,11 @@ pub struct ServerStatus {
     /// An ISO 8601 timestamp of when the server was started
     #[serde(rename = "started")]
     pub started: chrono::DateTime<chrono::Utc>,
+
+    /// A unique identifier generated when the server starts. Clients can compare this against a previously observed value to detect that they are talking to a different server instance (e.g. one that was restarted), and therefore that any persisted bearer token may be stale.
+    #[serde(rename = "server_id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_id: Option<String>,
 }
 
 impl ServerStatus {
@@ -4389,6 +4394,7 @@ impl ServerStatus {
             version,
             process_id,
             started,
+            server_id: None,
         }
     }
 }
@@ -4416,6 +4422,9 @@ impl std::fmt::Display for ServerStatus {
             Some("process_id".to_string()),
             Some(self.process_id.to_string()),
             // Skipping non-primitive type started in query parameter serialization
+            self.server_id
+                .as_ref()
+                .map(|server_id| ["server_id".to_string(), server_id.to_string()].join(",")),
         ];
 
         write!(
@@ -4446,6 +4455,7 @@ impl std::str::FromStr for ServerStatus {
             pub version: Vec<String>,
             pub process_id: Vec<i32>,
             pub started: Vec<chrono::DateTime<chrono::Utc>>,
+            pub server_id: Vec<String>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -4503,6 +4513,10 @@ impl std::str::FromStr for ServerStatus {
                     "started" => intermediate_rep.started.push(
                         <chrono::DateTime<chrono::Utc> as std::str::FromStr>::from_str(val)
                             .map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "server_id" => intermediate_rep.server_id.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
                     _ => {
                         return std::result::Result::Err(
@@ -4563,6 +4577,7 @@ impl std::str::FromStr for ServerStatus {
                 .into_iter()
                 .next()
                 .ok_or_else(|| "started missing in ServerStatus".to_string())?,
+            server_id: intermediate_rep.server_id.into_iter().next(),
         })
     }
 }

--- a/crates/kcserver/src/main.rs
+++ b/crates/kcserver/src/main.rs
@@ -354,11 +354,14 @@ async fn main() {
             }
         }
         None => {
-            // Generate a random token
+            // Generate a random token. We use 32 bytes (256 bits) of entropy;
+            // hex-encoded this is 64 characters, which is the maximum length
+            // that fits in the auth token HTTP header (see the token-file
+            // length check above).
             let mut rng = rand::thread_rng();
-            let mut hex_string = String::with_capacity(32);
+            let mut hex_string = String::with_capacity(64);
 
-            for _ in 0..8 {
+            for _ in 0..32 {
                 let byte: u8 = rng.gen();
                 hex_string.push_str(&format!("{:02x}", byte));
             }

--- a/crates/kcserver/src/server.rs
+++ b/crates/kcserver/src/server.rs
@@ -556,6 +556,11 @@ pub struct Server<C> {
     #[allow(dead_code)]
     token: Option<String>,
     started_time: std::time::Instant,
+    /// A unique identifier generated each time the server starts. Reported in
+    /// the server status so clients can detect when they are talking to a
+    /// different server instance and therefore that a persisted bearer token
+    /// may be stale.
+    server_id: String,
     kernel_sessions: Arc<RwLock<Vec<KernelSession>>>,
     client_sessions: Arc<RwLock<Vec<ClientSession>>>,
     idle_nudge_tx: Sender<Option<u32>>,
@@ -634,6 +639,7 @@ impl<C> Server<C> {
         Server {
             token,
             started_time: std::time::Instant::now(),
+            server_id: uuid::Uuid::new_v4().to_string(),
             marker: PhantomData,
             kernel_sessions,
             client_sessions: Arc::new(RwLock::new(vec![])),
@@ -695,6 +701,7 @@ impl<C> Server<C> {
         Server {
             token,
             started_time: std::time::Instant::now(),
+            server_id: uuid::Uuid::new_v4().to_string(),
             marker: PhantomData,
             kernel_sessions,
             client_sessions: Arc::new(RwLock::new(vec![])),
@@ -750,6 +757,7 @@ impl<C> Server<C> {
         Server {
             token,
             started_time: std::time::Instant::now(),
+            server_id: uuid::Uuid::new_v4().to_string(),
             marker: PhantomData,
             kernel_sessions,
             client_sessions: Arc::new(RwLock::new(vec![])),
@@ -2161,6 +2169,7 @@ where
             started: started_datetime,
             uptime_seconds: uptime_seconds as i32,
             version: env!("CARGO_PKG_VERSION").to_string(),
+            server_id: Some(self.server_id.clone()),
         };
 
         Ok(kallichore_api::ServerStatusResponse::ServerStatusAndInformation(resp))

--- a/kallichore.json
+++ b/kallichore.json
@@ -1340,6 +1340,10 @@
             "type": "string",
             "format": "date-time",
             "description": "An ISO 8601 timestamp of when the server was started"
+          },
+          "server_id": {
+            "type": "string",
+            "description": "A unique identifier generated when the server starts. Clients can compare this against a previously observed value to detect that they are talking to a different server instance (e.g. one that was restarted), and therefore that any persisted bearer token may be stale."
           }
         },
         "required": [


### PR DESCRIPTION
Quick change to add a server ID so you can check (without needing to supply auth) whether the Kallichore instance you're connecting to is the one you think it is. 

This supports https://github.com/posit-dev/positron/issues/14386, but doesn't fix the issue on its own (some substantial Positron changes are needed as well). See https://github.com/posit-dev/positron/pull/14475 for more info.