### PR TITLE
fix: use adopted kernel's own HMAC key in PUT /sessions/{id}/adopt

### DIFF
--- a/crates/kcserver/src/kernel_connection.rs
+++ b/crates/kcserver/src/kernel_connection.rs
@@ -44,4 +44,82 @@ impl KernelConnection {
             hmac_key: Some(hmac_key),
         })
     }
+
+    /// Return a copy of this connection that signs/validates messages with
+    /// `key` instead of the key it was created with.
+    ///
+    /// This is used when adopting a kernel that's already running (see
+    /// `KernelSession::connect`): the kernel was started with its own signing
+    /// key, which is only known once the adopting client sends it in the
+    /// `ConnectionInfo` it supplies. That key must be trusted over the key
+    /// this session was created with, or messages to/from the adopted kernel
+    /// will fail HMAC validation.
+    ///
+    /// An empty key follows the Jupyter convention that no key means messages
+    /// are unsigned.
+    pub fn with_key(&self, key: &str) -> Result<Self, anyhow::Error> {
+        let mut connection = self.clone();
+        if key.is_empty() {
+            connection.key = None;
+            connection.hmac_key = None;
+        } else {
+            connection.hmac_key = Some(Hmac::<Sha256>::new_from_slice(key.as_bytes())?);
+            connection.key = Some(key.to_string());
+        }
+        Ok(connection)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a `KernelConnection` directly (bypassing `from_session`) so
+    /// tests don't need to construct a full `models::NewSession`.
+    fn test_connection(key: &str) -> KernelConnection {
+        let (key, hmac_key) = if key.is_empty() {
+            (None, None)
+        } else {
+            let hmac_key = Hmac::<Sha256>::new_from_slice(key.as_bytes()).unwrap();
+            (Some(key.to_string()), Some(hmac_key))
+        };
+        KernelConnection {
+            session_id: "test-session".to_string(),
+            username: "test-user".to_string(),
+            key,
+            protocol_version: "5.3".to_string(),
+            hmac_key,
+        }
+    }
+
+    #[test]
+    fn with_key_installs_the_supplied_key() {
+        let original = test_connection("original-key");
+        let adopted = original.with_key("adopted-key").unwrap();
+
+        assert_eq!(adopted.key.as_deref(), Some("adopted-key"));
+        assert_eq!(adopted.session_id, original.session_id);
+        assert_eq!(adopted.username, original.username);
+
+        // The HMAC state was actually rebuilt from the new key, not just the
+        // `key` string: signing the same content produces a different
+        // signature under each connection's key.
+        let mut original_mac = original.hmac_key.unwrap();
+        let mut adopted_mac = adopted.hmac_key.unwrap();
+        original_mac.update(b"payload");
+        adopted_mac.update(b"payload");
+        assert_ne!(
+            original_mac.finalize().into_bytes(),
+            adopted_mac.finalize().into_bytes()
+        );
+    }
+
+    #[test]
+    fn with_key_empty_disables_signing() {
+        let original = test_connection("original-key");
+        let adopted = original.with_key("").unwrap();
+
+        assert_eq!(adopted.key, None);
+        assert!(adopted.hmac_key.is_none());
+    }
 }

--- a/crates/kcserver/src/kernel_session/mod.rs
+++ b/crates/kcserver/src/kernel_session/mod.rs
@@ -345,8 +345,9 @@ impl KernelSession {
 
         let startup_proxy_tx = startup_tx.clone();
         tokio::spawn(async move {
+            let connection = kernel.connection.clone();
             kernel
-                .start_zmq_proxy(connection_file.clone(), startup_proxy_tx)
+                .start_zmq_proxy(connection_file.clone(), connection, startup_proxy_tx)
                 .await;
         });
 
@@ -433,6 +434,19 @@ impl KernelSession {
             .update_connection_file(connection_file.clone())
             .await;
 
+        // The kernel we're adopting is already running, signing and
+        // validating messages with its own key -- the one in
+        // `connection_file.info.key`, taken from the `ConnectionInfo` the
+        // adopting client supplied. That's not the same key this session was
+        // created with (`self.connection`'s key is generated locally when a
+        // new session is created, before an adopted kernel's real key is
+        // known), so it must be used in place of the session's own key for
+        // all further communication with this kernel.
+        let connection = self
+            .connection
+            .with_key(&connection_file.info.key)
+            .map_err(KSError::SessionConnectionFailed)?;
+
         // Create a channel to receive startup status
         let (startup_tx, startup_rx) = async_channel::unbounded::<StartupStatus>();
 
@@ -444,7 +458,9 @@ impl KernelSession {
                 kernel.connection.session_id
             );
 
-            kernel.start_zmq_proxy(connection_file, startup_tx).await;
+            kernel
+                .start_zmq_proxy(connection_file, connection, startup_tx)
+                .await;
 
             log::debug!(
                 "[session {}] ZeroMQ proxy for adopted kernel has exited",
@@ -584,16 +600,22 @@ impl KernelSession {
     }
 
     /// Start the ZeroMQ proxy for this kernel session.
+    ///
+    /// `connection` carries the signing key to use for this proxy's
+    /// lifetime. It's usually `self.connection`, but adopted kernels (see
+    /// `connect`) sign with a key that isn't known until the adopting client
+    /// supplies it, so callers pass a corrected connection in that case.
     async fn start_zmq_proxy(
         &self,
         connection_file: ConnectionFile,
+        connection: KernelConnection,
         status_tx: Sender<StartupStatus>,
     ) {
         use crate::{error::KSError, zmq_ws_proxy::ZmqWsProxy};
 
         let mut proxy = ZmqWsProxy::new(
             connection_file.clone(),
-            self.connection.clone(),
+            connection,
             self.state.clone(),
             self.ws_json_tx.clone(),
             self.ws_zmq_rx.clone(),


### PR DESCRIPTION
## Summary

`PUT /sessions/{id}/adopt` accepts a `ConnectionInfo` for an already-running kernel, but the session's ZeroMQ proxy still signs and validates with the key generated server-side by `PUT /sessions`. For kernels with a non-empty Jupyter signing key, the first reply (`kernel_info_reply`) fails HMAC validation and adopt returns HTTP 500 `KS-6 "HMAC signature validation failed"`. As shipped, adopt can only reattach to kernels with an empty key (unsigned) or a connection file this same server instance wrote — which rules out the crash-recovery case, where kernels survive a supervisor crash and a fresh kcserver adopts them from persisted connection info.

Root cause: `new_session` builds the session's `KernelConnection` from a random server-generated key ([`server.rs#L1451-L1453`](https://github.com/posit-dev/kallichore/blob/136da45ad9c379a1e4a54546fb374ae559e7db89/crates/kcserver/src/server.rs#L1451-L1453)); `connect()` stores the adopted connection file (socket addresses) but hands the proxy `self.connection.clone()` — the supplied `ConnectionInfo.key` is never installed, and the proxy signs/validates with the stale key ([`zmq_ws_proxy.rs#L278`](https://github.com/posit-dev/kallichore/blob/136da45ad9c379a1e4a54546fb374ae559e7db89/crates/kcserver/src/zmq_ws_proxy.rs#L278), [`#L308`](https://github.com/posit-dev/kallichore/blob/136da45ad9c379a1e4a54546fb374ae559e7db89/crates/kcserver/src/zmq_ws_proxy.rs#L308), [`#L587`](https://github.com/posit-dev/kallichore/blob/136da45ad9c379a1e4a54546fb374ae559e7db89/crates/kcserver/src/zmq_ws_proxy.rs#L587)).

<details>
<summary>Reproduction (verified against <code>136da45</code> / v0.1.66)</summary>

1. Spawn kcserver A; `PUT /sessions` + `POST /sessions/{id}/start` an ark kernel (`signature_scheme: hmac-sha256`, non-empty key).
2. Save `GET /sessions/{id}/connection_info` (includes the kernel's real signing `key`).
3. `SIGKILL` kcserver A — the kernel process survives.
4. Spawn kcserver B; `PUT /sessions` with the same session ID (this generates a brand-new random key, unrelated to step 2's).
5. `PUT /sessions/{id}/adopt` with the saved connection info.
6. Response: `500`, `KS-6 "HMAC signature validation failed"`, ~10–40 ms after the call (the kernel's first signed reply).

</details>

## Fix

- Add `KernelConnection::with_key()` — returns a copy with HMAC state rebuilt from a supplied key, mirroring `from_session`. An empty key produces `key: None, hmac_key: None`, matching the existing "no key means unsigned" convention (`ConnectionFile::generate`, `WireMessage::{from_jupyter,to_jupyter}`).
- `KernelSession::connect()` derives the proxy's connection via `self.connection.with_key(&connection_file.info.key)`.
- `start_zmq_proxy()` takes the `KernelConnection` as an explicit parameter, so both callers are explicit about which key is in play; `start()` (freshly-spawned kernels) passes `self.connection.clone()` as before — no behavior change on that path.
- The session's stored connection is deliberately left unchanged: signing happens only inside the proxy, `GET connection_info` reads the shared connection file that adopt already stores via `update_connection_file()`, and restart-after-adopt spawns a fresh kernel with a fresh self-consistent connection file.

<details>
<summary>Alternatives considered, and why other key consumers don't need changes</summary>

**Alternative: add a `key` field to `PUT /sessions` (`newSession`)** so a recreating client pre-supplies the old key. A crash-recovering supervisor does have the key at recreate time (it persisted `connection_info` before the crash), so this would work — but adopt already receives the authoritative `ConnectionInfo`, key included, so fixing adopt needs no API change; a `newSession` key field would widen the API and force callers to keep two requests consistent; and `newSession` primarily serves fresh spawns, where key generation should stay server-side.

**Alternative: mutate `self.connection` in place inside `connect()`.** `KernelSession` is `Clone` with a plain (non-`Arc`) `connection` field, and `find_session()` clones a fresh copy per request — mutating the clone inside `connect()` would not propagate to the copy in the server's session list, making it a partial, misleading fix. Correcting that "for real" means replacing the session in the list or moving the key into the shared `Arc<RwLock<KernelState>>` — a larger refactor than this bug warrants. Threading the corrected connection to the one place it's load-bearing (the proxy) is the minimal honest fix.

**Other `connection.key`/`hmac_key` consumers (grep-verified):**

- `start()` (`kernel_session/mod.rs:205`) — writes the connection file for a kernel it spawns itself; both sides agree by construction. Restart-after-adopt spawns a new kernel with a new self-consistent file.
- `ensure_connection_file()` fallback — only generates a file when none is stored; `connect()` always stores the adopted file first, so this path is never hit post-adopt.
- `GET /sessions/{id}/connection_info` — reads the shared `state.connection_file`, which adopt populates; already reflects the adopted key.
- `interrupt()`/`shutdown()`/restart — enqueue unsigned `JupyterMessage`s; signing happens exclusively in the proxy this fix corrects.
- `registration_socket.rs` (JEP 66) — only exercised by `start()`, not by adopt.

</details>

## Relation to #14

This is the adopt/reconnect half of crash recovery (#14): a supervisor still needs to persist `connection_info` durably before a crash, but once it has that metadata, kcserver can now reattach to the surviving kernel. Durable persistence stays the supervisor's job and isn't attempted here.

## Validation

- `cargo test -p kcserver`: passes (includes two new `KernelConnection::with_key` unit tests).
- End-to-end crash probe against this branch: kill kcserver A → start kcserver B → recreate session → adopt saved connection info → **HTTP 200 with `kernel_info` (~3 ms)**, channels websocket works, pre-crash kernel state intact (`exists("x") && x == 99`), clean shutdown, no orphaned processes. The same probe reproduces the HTTP 500 `KS-6` failure on unmodified `136da45`.
- `cargo fmt --check` / `cargo clippy -- -D warnings`: fail identically on unmodified `main` for pre-existing reasons (drift in untouched files; `large_enum_variant`/`too_many_arguments` in generated `kallichore_api`). The two files this PR touches are fmt-clean.

Out of scope: adopt's `get_kernel_info()` has no timeout ([`kernel_session/mod.rs#L626-L641`](https://github.com/posit-dev/kallichore/blob/136da45ad9c379a1e4a54546fb374ae559e7db89/crates/kcserver/src/kernel_session/mod.rs#L626-L641)) — if an adopted kernel connects but never answers, the PUT hangs. Separate latent issue, not addressed here.