### PR TITLE
 Replace the server connection file with a client-owned handshake socket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,9 +140,9 @@ Example usage:
 
 ### Connection Handshake (`--handshake-socket`)
 
-Instead of writing a connection file that the client polls for, kcserver reports its
-connection details over a **client-owned handshake socket**. This avoids the file-scanning
-race some antivirus software introduces on Windows and keeps the bearer token off disk.
+kcserver reports its connection details over a **client-owned handshake socket**. This avoids
+the file-scanning race some antivirus software introduces on Windows and keeps the bearer token
+off disk.
 
 - The client creates and listens on a same-user handshake endpoint (a Unix domain socket on
   Unix, a named pipe on Windows) *before* launching kcserver.
@@ -155,8 +155,9 @@ race some antivirus software introduces on Windows and keeps the bearer token of
 - The main transport is independent of the handshake socket, so `--handshake-socket` never
   influences transport selection. When `--handshake-socket` is omitted, kcserver logs its address
   and generated token to the console (convenient for manual/dev runs).
-- The old `--connection-file` mechanism has been removed. (Note: this is unrelated to the Jupyter
-  *kernel* connection file in `connection_file.rs`, which still exists.)
+
+(Note: this is unrelated to the Jupyter *kernel* connection file in `connection_file.rs`, which
+still exists.)
 
 Example usage:
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,38 @@ Example usage:
 ./target/debug/kcserver --transport named-pipe
 ```
 
+### Connection Handshake (`--handshake-socket`)
+
+Instead of writing a connection file that the client polls for, kcserver reports its
+connection details over a **client-owned handshake socket**. This avoids the file-scanning
+race some antivirus software introduces on Windows and keeps the bearer token off disk.
+
+- The client creates and listens on a same-user handshake endpoint (a Unix domain socket on
+  Unix, a named pipe on Windows) *before* launching kcserver.
+- kcserver is launched with `--handshake-socket <path>` plus `--transport <tcp|socket|named-pipe>`.
+- After binding its main transport, kcserver connects to the handshake socket, writes a single
+  JSON document (transport + address + `bearer_token` + `server_id` + pid + log path), and closes.
+  See the `handshake_socket` module (`crates/kcserver/src/handshake_socket.rs`) for the payload.
+- The handshake happens only at initial launch; reconnects use persisted state and perform no new
+  handshake.
+- The main transport is independent of the handshake socket, so `--handshake-socket` never
+  influences transport selection. When `--handshake-socket` is omitted, kcserver logs its address
+  and generated token to the console (convenient for manual/dev runs).
+- The old `--connection-file` mechanism has been removed. (Note: this is unrelated to the Jupyter
+  *kernel* connection file in `connection_file.rs`, which still exists.)
+
+Example usage:
+```bash
+# Report over a handshake socket, TCP main transport
+./target/debug/kcserver --handshake-socket /path/to/handshake.sock --transport tcp
+
+# Handshake socket with a Unix-domain-socket main transport (macOS/Linux)
+./target/debug/kcserver --handshake-socket /path/to/handshake.sock --transport socket
+
+# Handshake named pipe with a named-pipe main transport (Windows)
+./target/debug/kcserver.exe --handshake-socket \\.\pipe\kc-handshake --transport named-pipe
+```
+
 ### WebSocket Protocol Support
 
 **Unix Domain Sockets**: Starting with this version, Unix domain socket kernel client sessions use the WebSocket protocol instead of raw JSON. This enables clients to connect using `ws+unix:` URLs and provides a consistent WebSocket interface across all transport types.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rk -- LSP over TCP --> r
 
 To run Kallichore, first get a copy of the server from the GitHub Releases page on this repository (or build your own; see below for instructions). This release contains a pre-built binary named `kcserver` for your platform.
 
-For most use cases, it's recommended to run `kcserver` with the `--handshake-socket` argument. Instead of writing a connection file that your client polls for, your client creates and listens on a **handshake socket** first, then launches `kcserver` pointing at it. The server binds its main transport and connects back to the handshake socket exactly once to report its connection details (including the bearer token), then closes. This avoids the file-scanning race some antivirus software introduces on Windows and keeps the token off disk.
+For most use cases, it's recommended to run `kcserver` with the `--handshake-socket` argument. Your client creates and listens on a **handshake socket** first, then launches `kcserver` pointing at it. The server binds its main transport and connects back to the handshake socket exactly once to report its connection details (including the bearer token), then closes. This avoids the file-scanning race some antivirus software introduces on Windows and keeps the token off disk.
 
 On a typical Unix-like system, your client creates a Unix domain socket (in a same-user-only directory), then launches the server telling it to use domain sockets as the main transport (TCP and named pipes are also supported; see [Connection Methods](#connection-methods) for details):
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ rk -- LSP over TCP --> r
 
 To run Kallichore, first get a copy of the server from the GitHub Releases page on this repository (or build your own; see below for instructions). This release contains a pre-built binary named `kcserver` for your platform.
 
-For most use cases, it's recommended to run `kcserver` with the `--connection-file` argument to have Kallichore generate a connection file for your client. On a typical Unix-like system, you might use a temporary file for connection information and tell Kallichore to use domain sockets as the transport (TCP and named pipes are also supported; see [Connection Methods](#connection-methods) for details):
+For most use cases, it's recommended to run `kcserver` with the `--handshake-socket` argument. Instead of writing a connection file that your client polls for, your client creates and listens on a **handshake socket** first, then launches `kcserver` pointing at it. The server binds its main transport and connects back to the handshake socket exactly once to report its connection details (including the bearer token), then closes. This avoids the file-scanning race some antivirus software introduces on Windows and keeps the token off disk.
+
+On a typical Unix-like system, your client creates a Unix domain socket (in a same-user-only directory), then launches the server telling it to use domain sockets as the main transport (TCP and named pipes are also supported; see [Connection Methods](#connection-methods) for details):
 
 ```bash
-./kcserver --transport socket --connection-file /tmp/kc-connection-file.json
+./kcserver --transport socket --handshake-socket /run/user/1000/kc-handshake.sock
 ```
 
-The server will start up and listen for incoming connections on the specified transport and generate a bearer auth token (see below for [Security Considerations](#security-considerations)). Your client can read connection details from the connection file and connect to the server using the appropriate transport. The connection file looks like this:
+The server will start up, bind its main transport, generate a bearer auth token (see below for [Security Considerations](#security-considerations)), and write a single JSON document to the handshake socket describing how to connect. Your client reads that document to EOF and connects to the main transport. The handshake payload looks like this:
 
 ```json
 {
@@ -52,9 +54,16 @@ The server will start up and listen for incoming connections on the specified tr
   "server_path": "/path/to/kcserver",
   "server_pid": 5259,
   "bearer_token": "4dea37b8a3b3e09f",
+  "server_id": "b1f0c2e4-...",
   "log_path": null
 }
 ```
+
+On Windows, the handshake socket is a named pipe your client creates (e.g. `\\.\pipe\kc-handshake-...`); everything else is identical.
+
+The handshake happens only at initial launch. If your client needs to reconnect (for example after a reload), it should persist the reported connection details and connect directly; the server is not re-launched and performs no new handshake.
+
+If `--handshake-socket` is omitted, the server logs its address and (if generated) its auth token to the console instead, which is convenient for manual and development runs.
 
 See Kallichore's help page for a full list of command-line options:
 
@@ -86,7 +95,7 @@ The following steps are recommended to ensure the security of your Kallichore in
 
 1. **Use a low-privilege user account**: Run Kallichore under a non-privileged user account, not as root. Because Jupyter kernels are basically code execution environments, presume that giving a user access to Kallichore's API is equivalent to giving them shell access.
 2. **Use IPC, not TCP**: If running Kallichore locally, use domain sockets (Unix/macOS) or named pipes (Windows) as the transport. These transports are more secure than TCP, as they can be locked down with file system permissions and do not expose the server to the network.
-3. **Secure the authentication token**: Kallichore uses a simple bearer token for authentication. If generating the token yourself, pass it as a file (so that it is not exposed in the process list) and delete it once the server has started. If allowing the server to generate the token, delete the connection file once it has been read.
+3. **Secure the authentication token**: Kallichore uses a simple bearer token for authentication. If generating the token yourself, pass it as a file (so that it is not exposed in the process list) and delete it once the server has started. If allowing the server to generate the token, deliver it via the handshake socket (`--handshake-socket`) rather than the console, and have your client keep the token in secure storage rather than on disk. The handshake socket itself should be created with same-user-only access control (a `0700` directory on Unix, or a current-user-only security descriptor on Windows).
 
 ## Development
 
@@ -161,13 +170,13 @@ Connections to individual kernels are made with WebSockets, which are establishe
 # Use specific port
 ./kcserver --port 8080
 
-# Create a connection file with TCP
-./kcserver --connection-file connection.json --transport tcp
+# Report connection details over a handshake socket, using TCP as the transport
+./kcserver --handshake-socket /path/to/handshake.sock --transport tcp
 ```
 
-#### Example TCP connection file
+#### Example TCP handshake payload
 
-When using `--connection-file`, the server writes connection details to the specified file:
+When using `--handshake-socket`, the server writes connection details to the handshake socket:
 
 ```json
 {
@@ -177,6 +186,7 @@ When using `--connection-file`, the server writes connection details to the spec
   "server_path": "/path/to/kcserver",
   "server_pid": 12345,
   "bearer_token": "your-auth-token",
+  "server_id": "b1f0c2e4-...",
   "log_path": "/path/to/logfile.log"
 }
 ```
@@ -190,17 +200,19 @@ When using domain sockets, the server listens on a specific socket file instead 
 #### Starting the server with Unix sockets
 
 ```bash
-# Use connection file with socket (default on Unix when using --connection-file)
-./kcserver --connection-file connection.json
+# Report connection details over a handshake socket, using a domain socket as the transport
+./kcserver --handshake-socket /path/to/handshake.sock --transport socket
 
-# Explicitly specify socket transport
-./kcserver --connection-file connection.json --transport socket
-
-# Use specific socket path
+# Use a specific socket path for the main transport
 ./kcserver --unix-socket /tmp/kallichore.sock
+
+# Use a specific socket path and report details over a handshake socket
+./kcserver --unix-socket /tmp/kallichore.sock --handshake-socket /path/to/handshake.sock
 ```
 
-#### Example Unix socket connection file
+The server sets the main socket file to owner-only (`0600`) permissions as defense-in-depth.
+
+#### Example Unix socket handshake payload
 
 ```json
 {
@@ -209,6 +221,7 @@ When using domain sockets, the server listens on a specific socket file instead 
   "server_path": "/path/to/kcserver",
   "server_pid": 12345,
   "bearer_token": "your-auth-token",
+  "server_id": "b1f0c2e4-...",
   "log_path": "/path/to/logfile.log"
 }
 ```
@@ -222,14 +235,11 @@ When using named pipes, the server listens on a named pipe path instead of a TCP
 #### Starting the server with named pipes
 
 ```bash
-# Use connection file with named pipe (default on Windows when using --connection-file)
-kcserver.exe --connection-file connection.json
-
-# Explicitly specify named pipe transport
-kcserver.exe --connection-file connection.json --transport named-pipe
+# Report connection details over a handshake named pipe, using a named pipe as the transport
+kcserver.exe --handshake-socket \\.\pipe\kc-handshake --transport named-pipe
 ```
 
-#### Example named pipe connection file
+#### Example named pipe handshake payload
 
 ```json
 {
@@ -238,17 +248,20 @@ kcserver.exe --connection-file connection.json --transport named-pipe
   "server_path": "C:\\path\\to\\kcserver.exe",
   "server_pid": 12345,
   "bearer_token": "your-auth-token",
+  "server_id": "b1f0c2e4-...",
   "log_path": "C:\\path\\to\\logfile.log"
 }
 ```
 
 ### Transport Selection Rules
 
-The server automatically selects the appropriate transport based on:
+The server selects the main transport based on:
 
 1. **Explicit `--transport` flag**: Overrides all other settings
-2. **Connection file mode**: Defaults to `socket` on Unix, `named-pipe` on Windows, `tcp` elsewhere
-3. **Direct mode**: Uses `tcp` when no connection file is specified
+2. **`--unix-socket` (Unix)**: Infers `socket` when a socket path is given
+3. **Default**: Uses `tcp` otherwise
+
+Note that the main transport is independent of the handshake socket: a client may host a Unix-socket (or named-pipe) handshake while asking the server for a TCP main transport, so `--handshake-socket` never influences the transport selection.
 
 ### Security Considerations
 

--- a/crates/kcserver/src/handshake_socket.rs
+++ b/crates/kcserver/src/handshake_socket.rs
@@ -1,0 +1,200 @@
+//
+// handshake_socket.rs
+//
+// Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+// Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+//
+//
+
+//! Client-owned handshake socket support.
+//!
+//! The client creates and listens on a handshake socket, then launches the
+//! server pointing at it. Once the server has bound its main transport, it
+//! connects to the handshake socket and reports its connection details in a
+//! single JSON document. Because the client owns the socket, there is no
+//! filesystem artifact for antivirus to scan and no window in which the client
+//! cannot see the server's details; the bearer token also never touches disk.
+//!
+//! On Unix the handshake socket is a Unix domain socket; on Windows it is a
+//! named pipe. The client creates and secures the socket, so its permissions
+//! are the client's responsibility. This module only connects to the path it is
+//! given, writes the payload, and closes.
+
+use serde::{Deserialize, Serialize};
+
+use crate::transport::ServerConnectionType;
+
+/// The connection details reported to the client over the handshake socket.
+///
+/// Field names are snake_case to match the client's `KallichoreServerState`.
+/// Transport-specific address fields are omitted when not relevant.
+#[derive(Serialize, Deserialize)]
+pub struct HandshakePayload {
+    /// The port the server is listening on (TCP only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+
+    /// The full API basepath, starting with 'http' (TCP only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_path: Option<String>,
+
+    /// The path to the Unix domain socket (Unix only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub socket_path: Option<String>,
+
+    /// The named pipe path (Windows only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub named_pipe: Option<String>,
+
+    /// The transport type: "tcp", "socket", or "named-pipe"
+    pub transport: String,
+
+    /// The path to the server executable (this process)
+    pub server_path: String,
+
+    /// The PID of the server process
+    pub server_pid: u32,
+
+    /// The authentication token, if any (null when --token none)
+    pub bearer_token: Option<String>,
+
+    /// The path to the log file, if any
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_path: Option<String>,
+
+    /// A unique identifier generated each time the server starts. The client
+    /// uses it to detect that a persisted token belongs to a server that has
+    /// since been replaced.
+    pub server_id: String,
+}
+
+impl HandshakePayload {
+    /// Build a handshake payload from the resolved connection details.
+    pub fn new(
+        connection_info: &ServerConnectionType,
+        token: &Option<String>,
+        log_file: &Option<String>,
+        server_id: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        // Get the server path
+        let server_path = std::env::current_exe()?
+            .to_str()
+            .ok_or("Failed to convert server path to string")?
+            .to_string();
+
+        // Get the server PID
+        let server_pid = std::process::id();
+
+        // Fill in the transport-specific address fields based on the connection type
+        let payload = match connection_info {
+            ServerConnectionType::Tcp { port, base_path } => HandshakePayload {
+                port: Some(*port),
+                base_path: Some(base_path.clone()),
+                socket_path: None,
+                named_pipe: None,
+                transport: "tcp".to_string(),
+                server_path,
+                server_pid,
+                bearer_token: token.clone(),
+                log_path: log_file.clone(),
+                server_id: server_id.to_string(),
+            },
+            #[cfg(unix)]
+            ServerConnectionType::Socket { socket_path, .. } => HandshakePayload {
+                port: None,
+                base_path: None,
+                socket_path: Some(socket_path.clone()),
+                named_pipe: None,
+                transport: "socket".to_string(),
+                server_path,
+                server_pid,
+                bearer_token: token.clone(),
+                log_path: log_file.clone(),
+                server_id: server_id.to_string(),
+            },
+            #[cfg(windows)]
+            ServerConnectionType::NamedPipe { pipe_name } => HandshakePayload {
+                port: None,
+                base_path: None,
+                socket_path: None,
+                named_pipe: Some(pipe_name.clone()),
+                transport: "named-pipe".to_string(),
+                server_path,
+                server_pid,
+                bearer_token: token.clone(),
+                log_path: log_file.clone(),
+                server_id: server_id.to_string(),
+            },
+        };
+
+        Ok(payload)
+    }
+}
+
+/// Perform the handshake: serialize the payload, connect to the client's
+/// handshake socket, write the JSON document, and close.
+///
+/// This runs only at initial launch. A failure here is fatal for the launch,
+/// since the client will never learn how to reach us; callers should exit
+/// non-zero on error.
+pub async fn perform_handshake(
+    handshake_path: &str,
+    payload: &HandshakePayload,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Serialize to JSON and append a trailing newline. The client reads to EOF,
+    // so the newline is not strictly required, but it is harmless and makes the
+    // stream easier to read.
+    let mut json = serde_json::to_string(payload)?;
+    json.push('\n');
+
+    connect_and_send(handshake_path, json.as_bytes()).await?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn connect_and_send(path: &str, payload: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::UnixStream;
+
+    let mut stream = UnixStream::connect(path).await?;
+    stream.write_all(payload).await?;
+    // Half-close the write side so the client sees EOF.
+    stream.shutdown().await?;
+    Ok(())
+}
+
+#[cfg(windows)]
+async fn connect_and_send(
+    pipe_name: &str,
+    payload: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::time::Duration;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::windows::named_pipe::ClientOptions;
+    use windows::Win32::Foundation::ERROR_PIPE_BUSY;
+
+    // The client's named pipe instance may not be ready to accept a connection
+    // yet (ERROR_PIPE_BUSY). Retry a bounded number of times before giving up.
+    const MAX_ATTEMPTS: u32 = 20;
+    let pipe_busy = ERROR_PIPE_BUSY.0 as i32;
+    let mut client = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match ClientOptions::new().open(pipe_name) {
+            Ok(c) => {
+                client = Some(c);
+                break;
+            }
+            Err(e) if e.raw_os_error() == Some(pipe_busy) && attempt + 1 < MAX_ATTEMPTS => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => return Err(Box::new(e)),
+        }
+    }
+
+    let mut client =
+        client.ok_or_else(|| "Timed out waiting for handshake named pipe to become available")?;
+    client.write_all(payload).await?;
+    client.flush().await?;
+    Ok(())
+}

--- a/crates/kcserver/src/main.rs
+++ b/crates/kcserver/src/main.rs
@@ -21,6 +21,7 @@ use simplelog::{ColorChoice, CombinedLogger, Config, TermLogger, TerminalMode, W
 mod connection_file;
 mod error;
 mod execution_queue;
+mod handshake_socket;
 mod heartbeat;
 mod jupyter_messages;
 mod kernel_connection;
@@ -41,7 +42,7 @@ mod wire_message_header;
 mod working_dir;
 mod zmq_ws_proxy;
 
-use transport::{ServerConnectionType, TransportConfig, TransportError, TransportType};
+use transport::{TransportConfig, TransportError, TransportType};
 
 /// Validate command line arguments for consistency and correctness
 fn validate_args(args: &Args) -> Result<(), String> {
@@ -110,23 +111,9 @@ fn determine_transport(args: &Args) -> String {
             return "socket".to_string();
         }
 
-        if args.connection_file.is_some() {
-            // Default to socket/named-pipe when using connection file
-            #[cfg(unix)]
-            {
-                "socket".to_string()
-            }
-            #[cfg(windows)]
-            {
-                "named-pipe".to_string()
-            }
-            #[cfg(not(any(unix, windows)))]
-            {
-                "tcp".to_string()
-            }
-        } else {
-            "tcp".to_string()
-        }
+        // Default to TCP. The handshake socket's transport is independent of the
+        // main transport, so it is never used to infer the transport here.
+        "tcp".to_string()
     }
 }
 
@@ -170,11 +157,15 @@ struct Args {
     #[arg(long)]
     log_file: Option<String>,
 
-    /// The path to a connection file. If specified, the server will write
-    /// connection details to the given file, choosing any options not specified
-    /// in the command line arguments (e.g., port, transport type).
+    /// Path to a client-owned handshake socket. On Unix this is a filesystem
+    /// path to a Unix domain socket the client is already listening on; on
+    /// Windows it is the name of a named pipe the client has created (e.g.
+    /// \\.\pipe\...). Immediately after binding its main transport, the server
+    /// connects to this socket, writes a single JSON document describing the
+    /// connection (transport, address, bearer token, server_id, pid, log path),
+    /// and closes.
     #[arg(long)]
-    connection_file: Option<String>,
+    handshake_socket: Option<String>,
 
     /// The number of hours of idle time before the server shuts down. The
     /// server is considered idle if all sessions are idle and no session is
@@ -209,10 +200,10 @@ struct Args {
     #[arg(long)]
     unix_socket: Option<String>,
 
-    /// The transport type to use when creating a connection file. Valid values
+    /// The transport type to use for the main server connection. Valid values
     /// are "tcp", "socket" (Unix only), and "named-pipe" (Windows only).
-    /// If not specified, defaults to "socket" on Unix and "named-pipe" on Windows
-    /// when using --connection-file, otherwise "tcp".
+    /// If not specified, defaults to "socket" when --unix-socket is given,
+    /// otherwise "tcp".
     #[arg(long)]
     transport: Option<String>,
 }
@@ -366,9 +357,9 @@ async fn main() {
                 hex_string.push_str(&format!("{:02x}", byte));
             }
 
-            // If the token is generated and no connection file is specified,
+            // If the token is generated and no handshake socket is specified,
             // log it to the console as there's otherwise no way to retrieve it
-            if args.connection_file.is_none() {
+            if args.handshake_socket.is_none() {
                 log::info!("Generated random auth token: {}", hex_string);
             }
 
@@ -389,24 +380,43 @@ async fn main() {
         env!("CARGO_PKG_VERSION")
     );
 
-    // Display connection information - already handled by transport.log_connection_info()
-
-    // Get connection info for file writing and main server socket before consuming transport
+    // Get connection info for the handshake and main server socket before consuming transport
     let connection_info = transport.to_server_connection_type();
     let main_server_socket = transport.main_server_socket();
 
-    // If a connection file path was specified, write the connection details to it
-    if let Some(connection_file_path) = &args.connection_file {
-        if let Err(e) = write_server_connection_file_new(
-            connection_file_path,
+    // Generate the server ID up front so we can report it in the handshake. The
+    // same ID is threaded into the server so the value reported here matches the
+    // one later returned from the status endpoint, which the client uses to
+    // detect a replaced server.
+    let server_id = uuid::Uuid::new_v4().to_string();
+
+    // If a handshake socket path was specified, connect to it and report the
+    // connection details. The transport's listener is already bound, so the
+    // reported address is valid; connections the client makes immediately after
+    // the handshake queue in the OS backlog until we start accepting below.
+    if let Some(handshake_path) = &args.handshake_socket {
+        let payload = match handshake_socket::HandshakePayload::new(
             &connection_info,
             &token,
             &args.log_file,
+            &server_id,
         ) {
-            log::error!("Failed to write connection file: {}", e);
+            Ok(payload) => payload,
+            Err(e) => {
+                log::error!("Failed to build handshake payload: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        if let Err(e) = handshake_socket::perform_handshake(handshake_path, &payload).await {
+            log::error!(
+                "Failed to report connection details over handshake socket '{}': {}",
+                handshake_path,
+                e
+            );
             std::process::exit(1);
         }
-        log::info!("Wrote connection details to {}", connection_file_path);
+        log::info!("Reported connection details over handshake socket {}", handshake_path);
     }
 
     log::debug!("Starting Kallichore");
@@ -420,6 +430,7 @@ async fn main() {
     // Pass the listener to the server
     server::create_with_listener(
         server_listener,
+        server_id,
         token,
         args.idle_shutdown_hours,
         args.log_level,
@@ -429,169 +440,4 @@ async fn main() {
         resource_sample_interval_ms,
     )
     .await;
-}
-
-/// Write server connection details to a file
-#[allow(dead_code)]
-fn write_server_connection_file(
-    path: &str,
-    port: u16,
-    token: &Option<String>,
-    log_file: &Option<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use serde::{Deserialize, Serialize};
-    use std::fs::File;
-    use std::io::Write;
-
-    #[derive(Serialize, Deserialize)]
-    struct ServerConnectionInfo {
-        /// The port the server is listening on
-        port: u16,
-
-        /// The full API basepath, starting with 'http'
-        base_path: String,
-
-        /// The path to the server executable (this process)
-        server_path: String,
-
-        /// The PID of the server process
-        server_pid: u32,
-
-        /// The authentication token, if any
-        bearer_token: Option<String>,
-
-        /// The path to the log file, if any
-        log_path: Option<String>,
-    }
-
-    // Get the server path
-    let server_path = std::env::current_exe()?
-        .to_str()
-        .ok_or("Failed to convert server path to string")?
-        .to_string();
-
-    // Get the server PID
-    let server_pid = std::process::id();
-
-    // Create the connection info struct
-    let connection_info = ServerConnectionInfo {
-        port,
-        base_path: format!("http://127.0.0.1:{}", port),
-        server_path,
-        server_pid,
-        bearer_token: token.clone(),
-        log_path: log_file.clone(),
-    };
-
-    // Serialize to JSON
-    let json = serde_json::to_string_pretty(&connection_info)?;
-
-    // Write to file
-    let mut file = File::create(path)?;
-    file.write_all(json.as_bytes())?;
-
-    Ok(())
-}
-
-/// Write server connection details to a file (new format supporting multiple transports)
-fn write_server_connection_file_new(
-    path: &str,
-    connection_info: &ServerConnectionType,
-    token: &Option<String>,
-    log_file: &Option<String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use serde::{Deserialize, Serialize};
-    use std::fs::File;
-    use std::io::Write;
-
-    #[derive(Serialize, Deserialize)]
-    struct ServerConnectionInfoNew {
-        /// The port the server is listening on (TCP only)
-        #[serde(skip_serializing_if = "Option::is_none")]
-        port: Option<u16>,
-
-        /// The full API basepath, starting with 'http' (TCP only)
-        #[serde(skip_serializing_if = "Option::is_none")]
-        base_path: Option<String>,
-
-        /// The path to the Unix domain socket (Unix only)
-        #[serde(skip_serializing_if = "Option::is_none")]
-        socket_path: Option<String>,
-
-        /// The named pipe path (Windows only)
-        #[serde(skip_serializing_if = "Option::is_none")]
-        named_pipe: Option<String>,
-
-        /// The transport type: "tcp", "socket", or "named-pipe"
-        transport: String,
-
-        /// The path to the server executable (this process)
-        server_path: String,
-
-        /// The PID of the server process
-        server_pid: u32,
-
-        /// The authentication token, if any
-        bearer_token: Option<String>,
-
-        /// The path to the log file, if any
-        log_path: Option<String>,
-    }
-
-    // Get the server path
-    let server_path = std::env::current_exe()?
-        .to_str()
-        .ok_or("Failed to convert server path to string")?
-        .to_string();
-
-    // Get the server PID
-    let server_pid = std::process::id();
-
-    // Create the connection info struct based on the connection type
-    let connection_info_new = match connection_info {
-        ServerConnectionType::Tcp { port, base_path } => ServerConnectionInfoNew {
-            port: Some(*port),
-            base_path: Some(base_path.clone()),
-            socket_path: None,
-            named_pipe: None,
-            transport: "tcp".to_string(),
-            server_path,
-            server_pid,
-            bearer_token: token.clone(),
-            log_path: log_file.clone(),
-        },
-        #[cfg(unix)]
-        ServerConnectionType::Socket { socket_path, .. } => ServerConnectionInfoNew {
-            port: None,
-            base_path: None,
-            socket_path: Some(socket_path.clone()),
-            named_pipe: None,
-            transport: "socket".to_string(),
-            server_path,
-            server_pid,
-            bearer_token: token.clone(),
-            log_path: log_file.clone(),
-        },
-        #[cfg(windows)]
-        ServerConnectionType::NamedPipe { pipe_name } => ServerConnectionInfoNew {
-            port: None,
-            base_path: None,
-            socket_path: None,
-            named_pipe: Some(pipe_name.clone()),
-            transport: "named-pipe".to_string(),
-            server_path,
-            server_pid,
-            bearer_token: token.clone(),
-            log_path: log_file.clone(),
-        },
-    };
-
-    // Serialize to JSON
-    let json = serde_json::to_string_pretty(&connection_info_new)?;
-
-    // Write to file
-    let mut file = File::create(path)?;
-    file.write_all(json.as_bytes())?;
-
-    Ok(())
 }

--- a/crates/kcserver/src/server.rs
+++ b/crates/kcserver/src/server.rs
@@ -108,6 +108,7 @@ pub enum ServerListener {
 
 pub async fn create_with_listener(
     listener: ServerListener,
+    server_id: String,
     token: Option<String>,
     idle_shutdown_hours: Option<u16>,
     log_level: Option<String>,
@@ -120,6 +121,7 @@ pub async fn create_with_listener(
             #[cfg(unix)]
             create_tcp_server(
                 tcp_listener,
+                server_id,
                 token,
                 idle_shutdown_hours,
                 log_level,
@@ -130,6 +132,7 @@ pub async fn create_with_listener(
             #[cfg(not(unix))]
             create_tcp_server(
                 tcp_listener,
+                server_id,
                 token,
                 idle_shutdown_hours,
                 log_level,
@@ -141,6 +144,7 @@ pub async fn create_with_listener(
         ServerListener::Unix(unix_listener) => {
             create_unix_server(
                 unix_listener,
+                server_id,
                 token,
                 idle_shutdown_hours,
                 log_level,
@@ -154,6 +158,7 @@ pub async fn create_with_listener(
         ServerListener::NamedPipe(pipe_name) => {
             create_named_pipe_server(
                 pipe_name,
+                server_id,
                 token,
                 idle_shutdown_hours,
                 log_level,
@@ -181,9 +186,13 @@ pub async fn create(
     // Default resource sample interval of 1000ms
     let resource_sample_interval_ms = 1000u64;
 
+    // Generate a fresh server ID for this standalone server instance
+    let server_id = uuid::Uuid::new_v4().to_string();
+
     #[cfg(unix)]
     create_tcp_server(
         listener,
+        server_id,
         token,
         idle_shutdown_hours,
         log_level,
@@ -194,6 +203,7 @@ pub async fn create(
     #[cfg(not(unix))]
     create_tcp_server(
         listener,
+        server_id,
         token,
         idle_shutdown_hours,
         log_level,
@@ -203,6 +213,7 @@ pub async fn create(
 }
 
 struct ServerConfig {
+    server_id: String,
     token: Option<String>,
     idle_shutdown_hours: Option<u16>,
     log_level: Option<String>,
@@ -217,6 +228,7 @@ struct ServerConfig {
 impl ServerConfig {
     #[cfg(unix)]
     fn new(
+        server_id: String,
         token: Option<String>,
         idle_shutdown_hours: Option<u16>,
         log_level: Option<String>,
@@ -226,6 +238,7 @@ impl ServerConfig {
         resource_sample_interval_ms: u64,
     ) -> Self {
         Self {
+            server_id,
             token,
             idle_shutdown_hours,
             log_level,
@@ -238,6 +251,7 @@ impl ServerConfig {
 
     #[cfg(not(unix))]
     fn new(
+        server_id: String,
         token: Option<String>,
         idle_shutdown_hours: Option<u16>,
         log_level: Option<String>,
@@ -245,6 +259,7 @@ impl ServerConfig {
         resource_sample_interval_ms: u64,
     ) -> Self {
         Self {
+            server_id,
             token,
             idle_shutdown_hours,
             log_level,
@@ -266,6 +281,7 @@ impl ServerConfig {
     #[cfg(unix)]
     fn create_server<C>(&self) -> Server<C> {
         Server::new(
+            self.server_id.clone(),
             self.token.clone(),
             self.idle_shutdown_hours,
             self.effective_log_level(),
@@ -279,6 +295,7 @@ impl ServerConfig {
     #[cfg(not(unix))]
     fn create_server<C>(&self) -> Server<C> {
         Server::new(
+            self.server_id.clone(),
             self.token.clone(),
             self.idle_shutdown_hours,
             self.effective_log_level(),
@@ -327,6 +344,7 @@ where
 
 async fn create_tcp_server(
     listener: tokio::net::TcpListener,
+    server_id: String,
     token: Option<String>,
     idle_shutdown_hours: Option<u16>,
     log_level: Option<String>,
@@ -335,6 +353,7 @@ async fn create_tcp_server(
 ) {
     #[cfg(unix)]
     let config = ServerConfig::new(
+        server_id,
         token,
         idle_shutdown_hours,
         log_level,
@@ -345,6 +364,7 @@ async fn create_tcp_server(
     );
     #[cfg(not(unix))]
     let config = ServerConfig::new(
+        server_id,
         token,
         idle_shutdown_hours,
         log_level,
@@ -400,6 +420,7 @@ async fn create_tcp_server(
 #[cfg(unix)]
 async fn create_unix_server(
     listener: tokio::net::UnixListener,
+    server_id: String,
     token: Option<String>,
     idle_shutdown_hours: Option<u16>,
     log_level: Option<String>,
@@ -408,6 +429,7 @@ async fn create_unix_server(
     resource_sample_interval_ms: u64,
 ) {
     let config = ServerConfig::new(
+        server_id,
         token,
         idle_shutdown_hours,
         log_level,
@@ -460,6 +482,16 @@ async fn create_unix_server(
                     // Connection shutdown errors are common and expected when clients
                     // disconnect - only log at debug level to avoid noise
                     let socket_info = socket_path.as_deref().unwrap_or("unknown");
+
+                    // Some clients keep the connection alive with a setting we
+                    // can't control, which causes hyper to fail shutting the
+                    // connection down. These "error shutting down connection"
+                    // errors are harmless, so suppress them entirely while
+                    // still logging every other kind of connection error.
+                    if e.to_string().contains("error shutting down connection") {
+                        return;
+                    }
+
                     log::debug!("Unix socket connection ended ({}): {}", socket_info, e);
                 }
             });
@@ -472,6 +504,7 @@ async fn create_unix_server(
 #[cfg(windows)]
 async fn create_named_pipe_server(
     pipe_name: String,
+    server_id: String,
     token: Option<String>,
     idle_shutdown_hours: Option<u16>,
     log_level: Option<String>,
@@ -480,6 +513,7 @@ async fn create_named_pipe_server(
     use tokio::net::windows::named_pipe::ServerOptions;
 
     let config = ServerConfig::new(
+        server_id,
         token,
         idle_shutdown_hours,
         log_level,
@@ -500,7 +534,16 @@ async fn create_named_pipe_server(
     // Create the server future that accepts connections on named pipe
     let server_future = async move {
         loop {
-            // Create a new named pipe server for each connection
+            // Create a new named pipe server for each connection.
+            //
+            // TODO: `ServerOptions` creates the pipe with the process default
+            // DACL. For owner-only access control (matching the Unix socket's
+            // 0600 mode), create the pipe with a `SECURITY_ATTRIBUTES` whose
+            // security descriptor grants access only to the current user's SID
+            // (and SYSTEM). tokio does not expose security attributes, so this
+            // means creating the pipe via raw `CreateNamedPipeW` and wrapping
+            // the handle with `NamedPipeServer::from_raw_handle`. The bearer
+            // token is the access gate in the meantime.
             let pipe_server = match ServerOptions::new().create(&pipe_name) {
                 Ok(server) => server,
                 Err(e) => {
@@ -598,6 +641,7 @@ pub struct Server<C> {
 impl<C> Server<C> {
     #[cfg(unix)]
     pub fn new(
+        server_id: String,
         token: Option<String>,
         idle_shutdown_hours: Option<u16>,
         log_level: Option<String>,
@@ -639,7 +683,7 @@ impl<C> Server<C> {
         Server {
             token,
             started_time: std::time::Instant::now(),
-            server_id: uuid::Uuid::new_v4().to_string(),
+            server_id,
             marker: PhantomData,
             kernel_sessions,
             client_sessions: Arc::new(RwLock::new(vec![])),
@@ -662,6 +706,7 @@ impl<C> Server<C> {
 
     #[cfg(windows)]
     pub fn new(
+        server_id: String,
         token: Option<String>,
         idle_shutdown_hours: Option<u16>,
         log_level: Option<String>,
@@ -701,7 +746,7 @@ impl<C> Server<C> {
         Server {
             token,
             started_time: std::time::Instant::now(),
-            server_id: uuid::Uuid::new_v4().to_string(),
+            server_id,
             marker: PhantomData,
             kernel_sessions,
             client_sessions: Arc::new(RwLock::new(vec![])),
@@ -718,6 +763,7 @@ impl<C> Server<C> {
 
     #[cfg(not(any(unix, windows)))]
     pub fn new(
+        server_id: String,
         token: Option<String>,
         idle_shutdown_hours: Option<u16>,
         log_level: Option<String>,
@@ -757,7 +803,7 @@ impl<C> Server<C> {
         Server {
             token,
             started_time: std::time::Instant::now(),
-            server_id: uuid::Uuid::new_v4().to_string(),
+            server_id,
             marker: PhantomData,
             kernel_sessions,
             client_sessions: Arc::new(RwLock::new(vec![])),

--- a/crates/kcserver/src/transport.rs
+++ b/crates/kcserver/src/transport.rs
@@ -200,6 +200,24 @@ impl Transport for UnixSocketTransport {
 
         let std_listener = std::os::unix::net::UnixListener::bind(&socket_path)?;
         std_listener.set_nonblocking(true)?;
+
+        // Restrict the socket to the owning user (0600). The socket may be
+        // created under XDG_RUNTIME_DIR (already user-private) or the shared
+        // temp directory (not private), so tightening the file mode ensures no
+        // other local user can connect regardless of where it lives. This is
+        // defense-in-depth alongside the bearer token.
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            if let Err(e) = std::fs::set_permissions(&socket_path, perms) {
+                log::warn!(
+                    "Failed to set restrictive permissions on socket '{}': {}",
+                    socket_path,
+                    e
+                );
+            }
+        }
+
         let listener = UnixListener::from_std(std_listener)?;
 
         let connection_info = UnixSocketConnectionInfo {

--- a/crates/kcserver/src/transport.rs
+++ b/crates/kcserver/src/transport.rs
@@ -453,7 +453,7 @@ impl TransportType {
         }
     }
 
-    /// Convert transport to ServerConnectionType for connection file compatibility
+    /// Resolve this transport's address into a `ServerConnectionType` for the handshake payload
     pub fn to_server_connection_type(&self) -> ServerConnectionType {
         match self {
             TransportType::Tcp(transport) => {
@@ -520,7 +520,7 @@ impl TransportType {
     }
 }
 
-/// Information about the server connection that gets written to the connection file
+/// Information about the server connection that is reported to the client over the handshake socket
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // Some fields may not be used on all platforms
 pub enum ServerConnectionType {

--- a/crates/kcserver/tests/common/mod.rs
+++ b/crates/kcserver/tests/common/mod.rs
@@ -53,11 +53,11 @@ impl ServerConfig {
     }
 
     #[cfg(windows)]
-    fn named_pipe(connection_file_path: &str) -> Self {
+    fn named_pipe(handshake_path: &str) -> Self {
         Self {
             args: vec![
-                "--connection-file".to_string(),
-                connection_file_path.to_string(),
+                "--handshake-socket".to_string(),
+                handshake_path.to_string(),
                 "--transport".to_string(),
                 "named-pipe".to_string(),
                 "--token".to_string(),
@@ -171,38 +171,24 @@ impl TestServer {
 
     #[cfg(windows)]
     async fn start_named_pipe_server() -> Self {
-        use tempfile::NamedTempFile;
+        use self::test_utils::HandshakeListener;
 
-        // Create a temporary connection file
-        let temp_file = NamedTempFile::new().expect("Failed to create temp connection file");
-        let connection_file_path = temp_file.path().to_string_lossy().to_string();
+        // The test hosts a handshake socket the server connects to at startup.
+        let handshake = HandshakeListener::create().await;
+        let handshake_path = handshake.path().to_string();
 
-        let config = ServerConfig::named_pipe(&connection_file_path);
+        let config = ServerConfig::named_pipe(&handshake_path);
         let child = create_server_process(config).await;
 
-        // Wait for the connection file to be created and read the pipe name from it
-        let mut pipe_name = None;
-        for _attempt in 0..100 {
-            if std::path::Path::new(&connection_file_path).exists() {
-                if let Ok(content) = std::fs::read_to_string(&connection_file_path) {
-                    if !content.trim().is_empty() {
-                        if let Ok(connection_info) =
-                            serde_json::from_str::<serde_json::Value>(&content)
-                        {
-                            if let Some(pipe_path) =
-                                connection_info.get("named_pipe").and_then(|v| v.as_str())
-                            {
-                                pipe_name = Some(pipe_path.to_string());
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
+        // Await the connection details (including the main named pipe).
+        let connection_info = handshake
+            .recv()
+            .await
+            .expect("Failed to receive handshake payload");
 
-        let pipe_name = pipe_name.expect("Failed to get pipe name from connection file");
+        let pipe_name = connection_info
+            .named_pipe
+            .expect("Missing named_pipe in handshake payload");
         println!("Named pipe server started with pipe: {}", pipe_name);
 
         // For named pipe mode, we need to communicate via the pipe

--- a/crates/kcserver/tests/common/test_utils.rs
+++ b/crates/kcserver/tests/common/test_utils.rs
@@ -190,28 +190,109 @@ pub fn create_server_command(args: &[&str]) -> Command {
     cmd
 }
 
-/// Wait for a connection file to be created with timeout
-pub async fn wait_for_connection_file(
-    connection_file_path: &std::path::Path,
-    timeout_attempts: u32,
-) -> Result<(), String> {
-    let mut attempts = 0;
-    while !connection_file_path.exists() && attempts < timeout_attempts {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        attempts += 1;
-        if attempts % 20 == 0 {
-            println!(
-                "Still waiting for connection file after {} attempts...",
-                attempts
-            );
+/// The connection details the server reports over the handshake socket. Mirrors
+/// the `HandshakePayload` struct on the server side.
+#[derive(serde::Deserialize, Debug, Clone)]
+#[allow(dead_code)]
+pub struct HandshakeConnectionInfo {
+    pub port: Option<u16>,
+    pub base_path: Option<String>,
+    pub socket_path: Option<String>,
+    pub named_pipe: Option<String>,
+    pub transport: String,
+    pub server_path: String,
+    pub server_pid: u32,
+    pub bearer_token: Option<String>,
+    pub log_path: Option<String>,
+    pub server_id: String,
+}
+
+/// A client-owned handshake endpoint that the server connects to once at
+/// startup to report its connection details. The test creates and listens on
+/// the endpoint first, passes `path()` to the server via `--handshake-socket`,
+/// then awaits the single JSON payload with `recv()`.
+pub struct HandshakeListener {
+    path: String,
+    #[cfg(unix)]
+    listener: tokio::net::UnixListener,
+    #[cfg(windows)]
+    server: tokio::net::windows::named_pipe::NamedPipeServer,
+}
+
+impl HandshakeListener {
+    /// Create and start listening on a fresh handshake endpoint.
+    pub async fn create() -> Self {
+        #[cfg(unix)]
+        {
+            let path = std::env::temp_dir()
+                .join(format!("kc-handshake-{}.sock", Uuid::new_v4()))
+                .to_string_lossy()
+                .to_string();
+            let listener =
+                tokio::net::UnixListener::bind(&path).expect("Failed to bind handshake socket");
+            HandshakeListener { path, listener }
+        }
+
+        #[cfg(windows)]
+        {
+            use tokio::net::windows::named_pipe::ServerOptions;
+            let path = format!(r"\\.\pipe\kc-handshake-{}", Uuid::new_v4().simple());
+            let server = ServerOptions::new()
+                .first_pipe_instance(true)
+                .create(&path)
+                .expect("Failed to create handshake named pipe");
+            HandshakeListener { path, server }
         }
     }
 
-    if !connection_file_path.exists() {
-        return Err("Connection file was not created within timeout".to_string());
+    /// The path/name to pass to the server via `--handshake-socket`.
+    pub fn path(&self) -> &str {
+        &self.path
     }
 
-    Ok(())
+    /// Await the single JSON payload the server writes, reading to EOF, and
+    /// return the parsed connection info. Fails if nothing arrives in time.
+    pub async fn recv(self) -> Result<HandshakeConnectionInfo, String> {
+        let read_fut = self.read_payload();
+        match tokio::time::timeout(Duration::from_secs(30), read_fut).await {
+            Ok(Ok(info)) => Ok(info),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err("Timed out waiting for handshake payload".to_string()),
+        }
+    }
+
+    #[cfg(unix)]
+    async fn read_payload(self) -> Result<HandshakeConnectionInfo, String> {
+        use tokio::io::AsyncReadExt;
+        let (mut stream, _) = self
+            .listener
+            .accept()
+            .await
+            .map_err(|e| format!("Failed to accept handshake connection: {}", e))?;
+        let mut buf = Vec::new();
+        stream
+            .read_to_end(&mut buf)
+            .await
+            .map_err(|e| format!("Failed to read handshake payload: {}", e))?;
+        serde_json::from_slice(&buf)
+            .map_err(|e| format!("Failed to parse handshake payload: {}", e))
+    }
+
+    #[cfg(windows)]
+    async fn read_payload(mut self) -> Result<HandshakeConnectionInfo, String> {
+        use tokio::io::AsyncReadExt;
+        self.server
+            .connect()
+            .await
+            .map_err(|e| format!("Failed to accept handshake connection: {}", e))?;
+        let mut buf = Vec::new();
+        self.server
+            .read_to_end(&mut buf)
+            .await
+            .map_err(|e| format!("Failed to read handshake payload: {}", e))?;
+        serde_json::from_slice(&buf)
+            .map_err(|e| format!("Failed to parse handshake payload: {}", e))
+    }
 }
 
 /// Create a session and handle the response

--- a/crates/kcserver/tests/handshake_tests.rs
+++ b/crates/kcserver/tests/handshake_tests.rs
@@ -1,18 +1,19 @@
 //
-// connection_file_tests.rs
+// handshake_tests.rs
 //
-// Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+// Copyright (C) 2026 Posit Software, PBC. All rights reserved.
 // Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 //
 
-//! Tests for server startup with connection files
+//! Tests for server startup with the client-owned handshake socket
 
 #[path = "common/mod.rs"]
 mod common;
 
-use common::test_utils::{cleanup_spawned_server, create_server_command, wait_for_connection_file};
+use common::test_utils::{
+    cleanup_spawned_server, create_server_command, HandshakeConnectionInfo, HandshakeListener,
+};
 use kallichore_api::{ApiNoContext, Client, ContextWrapperExt, ServerStatusResponse};
-use serde_json;
 use std::process::Child;
 use std::time::Duration;
 use swagger::{AuthData, ContextBuilder, EmptyContext, Push, XSpanIdString};
@@ -24,20 +25,6 @@ type ClientContext = swagger::make_context_ty!(
     Option<AuthData>,
     XSpanIdString
 );
-
-#[derive(serde::Deserialize)]
-#[allow(dead_code)]
-struct ServerConnectionInfo {
-    port: Option<u16>,
-    base_path: Option<String>,
-    socket_path: Option<String>,
-    named_pipe: Option<String>,
-    transport: String,
-    server_path: String,
-    server_pid: u32,
-    bearer_token: Option<String>,
-    log_path: Option<String>,
-}
 
 /// Create a client for the given base path
 async fn create_client_for_base_path(
@@ -87,25 +74,21 @@ async fn wait_for_server_ready(client: &Box<dyn ApiNoContext<ClientContext> + Se
     assert!(ready, "Server failed to become ready within timeout");
 }
 
-/// Test basic server startup with connection file
-async fn test_connection_file_startup(
+/// Launch a server that reports over a handshake socket, and return the parsed
+/// connection info plus the child process (caller cleans up).
+async fn test_handshake_startup(
     extra_args: &[&str],
-    test_name: &str,
     expected_transport: &str,
-) -> (ServerConnectionInfo, Child) {
-    let temp_dir = std::env::temp_dir();
-    let connection_file_path = temp_dir.join(format!(
-        "kallichore_test_{}_{}.json",
-        test_name,
-        Uuid::new_v4()
-    ));
-    let connection_file_str = connection_file_path.to_string_lossy().to_string();
+) -> (HandshakeConnectionInfo, Child) {
+    // The client (test) creates and listens on the handshake socket first.
+    let handshake = HandshakeListener::create().await;
+    let handshake_path = handshake.path().to_string();
 
     let mut args = vec![
         "--port",
         "0",
-        "--connection-file",
-        &connection_file_str,
+        "--handshake-socket",
+        &handshake_path,
         "--token",
         "none",
     ];
@@ -114,55 +97,38 @@ async fn test_connection_file_startup(
     let mut cmd = create_server_command(&args);
     let mut child = cmd.spawn().expect("Failed to start kcserver");
 
-    // Wait for connection file to be created
-    if let Err(e) = wait_for_connection_file(&connection_file_path, 100).await {
-        // Try to get error output from the process
-        if let Ok(output) = child.try_wait() {
-            if let Some(_exit_status) = output {
-                if let Ok(final_output) = child.wait_with_output() {
-                    if !final_output.stdout.is_empty() {
-                        println!(
-                            "Server stdout: {}",
-                            String::from_utf8_lossy(&final_output.stdout)
-                        );
-                    }
-                    if !final_output.stderr.is_empty() {
-                        println!(
-                            "Server stderr: {}",
-                            String::from_utf8_lossy(&final_output.stderr)
-                        );
-                    }
+    // Await the single JSON payload from the server.
+    let connection_info = match handshake.recv().await {
+        Ok(info) => info,
+        Err(e) => {
+            // Surface any server output to aid debugging.
+            let _ = child.kill();
+            if let Ok(output) = child.wait_with_output() {
+                if !output.stdout.is_empty() {
+                    println!("Server stdout: {}", String::from_utf8_lossy(&output.stdout));
                 }
-            } else {
-                let _ = child.kill();
-                let _ = child.wait();
+                if !output.stderr.is_empty() {
+                    println!("Server stderr: {}", String::from_utf8_lossy(&output.stderr));
+                }
             }
+            panic!("{}", e);
         }
-        panic!("{}", e);
-    }
-
-    // Read the connection file
-    let connection_content =
-        std::fs::read_to_string(&connection_file_path).expect("Failed to read connection file");
-
-    let connection_info: ServerConnectionInfo =
-        serde_json::from_str(&connection_content).expect("Failed to parse connection file");
+    };
 
     // Verify the connection info
     assert_eq!(connection_info.transport, expected_transport);
     assert!(connection_info.server_pid > 0, "PID should be greater than 0");
-
-    // Return both connection info and child process (caller will cleanup)
-    // Remove connection file but keep socket file for caller to test
-    let _ = std::fs::remove_file(&connection_file_path);
+    assert!(
+        !connection_info.server_id.is_empty(),
+        "server_id should be present"
+    );
 
     (connection_info, child)
 }
 
 #[tokio::test]
-async fn test_server_starts_with_connection_file() {
-    let (connection_info, child) =
-        test_connection_file_startup(&["--transport", "tcp"], "tcp", "tcp").await;
+async fn test_server_starts_with_handshake() {
+    let (connection_info, child) = test_handshake_startup(&["--transport", "tcp"], "tcp").await;
 
     assert!(connection_info.port.is_some(), "Port should be present");
     assert!(
@@ -175,7 +141,7 @@ async fn test_server_starts_with_connection_file() {
     );
 
     let port = connection_info.port.unwrap();
-    let base_path = connection_info.base_path.unwrap();
+    let base_path = connection_info.base_path.clone().unwrap();
 
     assert!(port > 0, "Port should be greater than 0");
     assert_eq!(
@@ -189,7 +155,7 @@ async fn test_server_starts_with_connection_file() {
     );
 
     println!(
-        "Successfully tested server with connection file. Port: {}",
+        "Successfully tested server with handshake socket. Port: {}",
         port
     );
 
@@ -198,11 +164,8 @@ async fn test_server_starts_with_connection_file() {
 }
 
 #[tokio::test]
-async fn test_server_connection_file_with_auth_token() {
+async fn test_server_handshake_with_auth_token() {
     let temp_dir = std::env::temp_dir();
-    let connection_file_path =
-        temp_dir.join(format!("kallichore_test_auth_{}.json", Uuid::new_v4()));
-    let connection_file_str = connection_file_path.to_string_lossy().to_string();
 
     // Create a temporary token file
     let token_file_path = temp_dir.join(format!("kallichore_test_token_{}.txt", Uuid::new_v4()));
@@ -210,11 +173,14 @@ async fn test_server_connection_file_with_auth_token() {
     let test_token = "test_auth_token_12345";
     std::fs::write(&token_file_path, test_token).expect("Failed to write token file");
 
+    let handshake = HandshakeListener::create().await;
+    let handshake_path = handshake.path().to_string();
+
     let args = [
         "--port",
         "0",
-        "--connection-file",
-        &connection_file_str,
+        "--handshake-socket",
+        &handshake_path,
         "--transport",
         "tcp",
         "--token",
@@ -224,23 +190,16 @@ async fn test_server_connection_file_with_auth_token() {
     let mut cmd = create_server_command(&args);
     let child = cmd.spawn().expect("Failed to start kcserver");
 
-    // Wait for connection file
-    wait_for_connection_file(&connection_file_path, 100)
+    let connection_info = handshake
+        .recv()
         .await
-        .expect("Connection file was not created");
-
-    // Read the connection file
-    let connection_content =
-        std::fs::read_to_string(&connection_file_path).expect("Failed to read connection file");
-
-    let connection_info: ServerConnectionInfo =
-        serde_json::from_str(&connection_content).expect("Failed to parse connection file");
+        .expect("Failed to receive handshake payload");
 
     // Verify the connection info includes the auth token
     assert!(connection_info.port.is_some());
     assert_eq!(connection_info.bearer_token, Some(test_token.to_string()));
 
-    let base_path = connection_info.base_path.unwrap();
+    let base_path = connection_info.base_path.clone().unwrap();
 
     // Test that we can connect with the proper auth token
     let client_with_auth = create_client_for_base_path(&base_path, Some(test_token)).await;
@@ -279,35 +238,30 @@ async fn test_server_connection_file_with_auth_token() {
 
     // Clean up
     cleanup_spawned_server(child);
-    let _ = std::fs::remove_file(&connection_file_path);
     let _ = std::fs::remove_file(&token_file_path);
 
     println!(
-        "Successfully tested server with connection file and auth token. Port: {}",
+        "Successfully tested server with handshake socket and auth token. Port: {}",
         connection_info.port.unwrap()
     );
 }
 
 #[tokio::test]
-async fn test_multiple_servers_different_ports() {
-    let temp_dir = std::env::temp_dir();
+async fn test_multiple_servers_different_ports_and_ids() {
     let mut servers = Vec::new();
-    let mut connection_files = Vec::new();
+    let mut ports = Vec::new();
+    let mut server_ids = Vec::new();
 
-    // Start 3 servers
-    for i in 0..3 {
-        let connection_file_path = temp_dir.join(format!(
-            "kallichore_test_multi_{}_{}.json",
-            i,
-            Uuid::new_v4()
-        ));
-        let connection_file_str = connection_file_path.to_string_lossy().to_string();
+    // Start 3 servers, each with its own handshake socket.
+    for _ in 0..3 {
+        let handshake = HandshakeListener::create().await;
+        let handshake_path = handshake.path().to_string();
 
         let args = [
             "--port",
             "0",
-            "--connection-file",
-            &connection_file_str,
+            "--handshake-socket",
+            &handshake_path,
             "--transport",
             "tcp",
             "--token",
@@ -316,96 +270,71 @@ async fn test_multiple_servers_different_ports() {
 
         let mut cmd = create_server_command(&args);
         let child = cmd.spawn().expect("Failed to start kcserver");
-        servers.push(child);
-        connection_files.push(connection_file_path);
 
-        // Small delay between starts
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
-
-    // Wait for all connection files and read them
-    let mut ports = Vec::new();
-    for (i, connection_file_path) in connection_files.iter().enumerate() {
-        wait_for_connection_file(connection_file_path, 100)
+        let connection_info = handshake
+            .recv()
             .await
-            .unwrap_or_else(|_| panic!("Connection file {} was not created within timeout", i));
+            .expect("Failed to receive handshake payload");
 
-        let connection_content =
-            std::fs::read_to_string(connection_file_path).expect("Failed to read connection file");
-
-        #[derive(serde::Deserialize)]
-        struct SimpleConnectionInfo {
-            port: u16,
-        }
-
-        let connection_info: SimpleConnectionInfo =
-            serde_json::from_str(&connection_content).expect("Failed to parse connection file");
-
-        ports.push(connection_info.port);
+        ports.push(connection_info.port.expect("Port should be present"));
+        server_ids.push(connection_info.server_id.clone());
+        servers.push(child);
     }
 
     // Verify all servers got different ports
     assert_eq!(ports.len(), 3);
-    ports.sort();
-    ports.dedup();
-    assert_eq!(ports.len(), 3, "All servers should have different ports");
-
-    // Verify all ports are valid
+    let mut sorted_ports = ports.clone();
+    sorted_ports.sort();
+    sorted_ports.dedup();
+    assert_eq!(
+        sorted_ports.len(),
+        3,
+        "All servers should have different ports"
+    );
     for port in &ports {
         assert!(*port > 0, "Port should be greater than 0");
     }
+
+    // Verify all servers got different server_ids
+    let mut sorted_ids = server_ids.clone();
+    sorted_ids.sort();
+    sorted_ids.dedup();
+    assert_eq!(
+        sorted_ids.len(),
+        3,
+        "All servers should have distinct server_ids"
+    );
 
     // Clean up
     for server in servers {
         cleanup_spawned_server(server);
     }
 
-    for connection_file_path in &connection_files {
-        let _ = std::fs::remove_file(connection_file_path);
-    }
-
     println!(
-        "Successfully tested multiple servers with different ports: {:?}",
-        ports
+        "Successfully tested multiple servers with different ports: {:?} and ids: {:?}",
+        ports, server_ids
     );
 }
 
 #[tokio::test]
-#[cfg(unix)]
-async fn test_server_connection_file_default_socket() {
-    let (connection_info, child) = test_connection_file_startup(&[], "socket_default", "socket").await;
+async fn test_server_handshake_default_tcp() {
+    // With no --transport (and no --unix-socket), the server defaults to TCP.
+    let (connection_info, child) = test_handshake_startup(&[], "tcp").await;
 
-    assert_eq!(connection_info.transport, "socket");
-    assert!(connection_info.socket_path.is_some());
-    assert!(connection_info.port.is_none());
-    assert!(connection_info.base_path.is_none());
+    assert_eq!(connection_info.transport, "tcp");
+    assert!(connection_info.port.is_some());
+    assert!(connection_info.base_path.is_some());
+    assert!(connection_info.socket_path.is_none());
     assert!(connection_info.named_pipe.is_none());
 
-    let socket_path = connection_info.socket_path.unwrap();
-
-    // Verify the socket file exists
-    assert!(
-        std::path::Path::new(&socket_path).exists(),
-        "Socket file should exist at: {}",
-        socket_path
-    );
-
-    // Test that we can connect to the socket
-    use std::os::unix::net::UnixStream;
-    let _stream =
-        UnixStream::connect(&socket_path).expect("Should be able to connect to the Unix socket");
-
-    // Clean up (this will remove the socket file)
     cleanup_spawned_server(child);
-    let _ = std::fs::remove_file(&socket_path);
 
-    println!("Successfully tested default socket transport with connection file");
+    println!("Successfully tested default TCP transport with handshake socket");
 }
 
 #[tokio::test]
-async fn test_server_connection_file_explicit_tcp_transport() {
-    let (connection_info, child) =
-        test_connection_file_startup(&["--transport", "tcp"], "tcp_explicit", "tcp").await;
+async fn test_server_handshake_explicit_tcp_transport() {
+    let (connection_info, child) = test_handshake_startup(&["--transport", "tcp"], "tcp").await;
 
     assert_eq!(connection_info.transport, "tcp");
     assert!(connection_info.port.is_some());
@@ -414,7 +343,7 @@ async fn test_server_connection_file_explicit_tcp_transport() {
     assert!(connection_info.named_pipe.is_none());
 
     let port = connection_info.port.unwrap();
-    let base_path = connection_info.base_path.unwrap();
+    let base_path = connection_info.base_path.clone().unwrap();
 
     // Verify the base path is correctly formatted
     assert_eq!(base_path, format!("http://127.0.0.1:{}", port));
@@ -422,18 +351,14 @@ async fn test_server_connection_file_explicit_tcp_transport() {
     // Clean up
     cleanup_spawned_server(child);
 
-    println!("Successfully tested explicit TCP transport with connection file");
+    println!("Successfully tested explicit TCP transport with handshake socket");
 }
 
 #[tokio::test]
 #[cfg(unix)]
-async fn test_server_connection_file_explicit_socket_transport() {
-    let (connection_info, child) = test_connection_file_startup(
-        &["--transport", "socket"],
-        "socket_explicit",
-        "socket",
-    )
-    .await;
+async fn test_server_handshake_explicit_socket_transport() {
+    let (connection_info, child) =
+        test_handshake_startup(&["--transport", "socket"], "socket").await;
 
     assert_eq!(connection_info.transport, "socket");
     assert!(connection_info.socket_path.is_some());
@@ -441,7 +366,7 @@ async fn test_server_connection_file_explicit_socket_transport() {
     assert!(connection_info.base_path.is_none());
     assert!(connection_info.named_pipe.is_none());
 
-    let socket_path = connection_info.socket_path.unwrap();
+    let socket_path = connection_info.socket_path.clone().unwrap();
 
     // Verify the socket file exists
     assert!(
@@ -449,6 +374,17 @@ async fn test_server_connection_file_explicit_socket_transport() {
         "Socket file should exist at: {}",
         socket_path
     );
+
+    // Verify the socket file is owner-only (0600)
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&socket_path)
+            .expect("Failed to stat socket file")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "Socket file should have 0600 permissions");
+    }
 
     // Test that we can connect to the socket
     use std::os::unix::net::UnixStream;
@@ -459,19 +395,17 @@ async fn test_server_connection_file_explicit_socket_transport() {
     cleanup_spawned_server(child);
     let _ = std::fs::remove_file(&socket_path);
 
-    println!("Successfully tested explicit socket transport with connection file");
+    println!("Successfully tested explicit socket transport with handshake socket");
 }
 
 #[tokio::test]
 async fn test_invalid_transport_parameter() {
-    let temp_dir = std::env::temp_dir();
-    let connection_file_path =
-        temp_dir.join(format!("kallichore_test_invalid_{}.json", Uuid::new_v4()));
-    let connection_file_str = connection_file_path.to_string_lossy().to_string();
+    let handshake = HandshakeListener::create().await;
+    let handshake_path = handshake.path().to_string();
 
     let args = [
-        "--connection-file",
-        &connection_file_str,
+        "--handshake-socket",
+        &handshake_path,
         "--transport",
         "invalid-transport",
         "--token",
@@ -481,14 +415,8 @@ async fn test_invalid_transport_parameter() {
     let mut cmd = create_server_command(&args);
     let output = cmd.output().expect("Failed to run command");
 
-    // Server should exit with error code
+    // Server should exit with error code (validation fails before the handshake)
     assert!(!output.status.success());
-
-    // Should not create connection file
-    assert!(!connection_file_path.exists());
-
-    // Clean up (just in case)
-    let _ = std::fs::remove_file(&connection_file_path);
 
     println!("Successfully tested invalid transport parameter rejection");
 }

--- a/crates/kcserver/tests/named_pipe_test.rs
+++ b/crates/kcserver/tests/named_pipe_test.rs
@@ -9,7 +9,12 @@
 //! Integration test for Windows named pipe functionality
 
 #[cfg(windows)]
+#[path = "common/mod.rs"]
+mod common;
+
+#[cfg(windows)]
 mod windows_named_pipe_tests {
+    use crate::common::test_utils::HandshakeListener;
     use std::process::{Command, Stdio};
     use std::time::Duration;
 
@@ -23,10 +28,11 @@ mod windows_named_pipe_tests {
 
     impl NamedPipeTestServer {
         async fn start() -> Self {
-            // Create a temporary connection file
-            let temp_file =
-                tempfile::NamedTempFile::new().expect("Failed to create temp connection file");
-            let connection_file_path = temp_file.path().to_string_lossy().to_string();
+            // The test hosts a handshake socket that the server connects to at
+            // startup to report its connection details (including the main
+            // named pipe it created for the API).
+            let handshake = HandshakeListener::create().await;
+            let handshake_path = handshake.path().to_string();
 
             // Try to use pre-built binary first, fall back to cargo run
             let binary_path = std::env::current_dir()
@@ -41,8 +47,8 @@ mod windows_named_pipe_tests {
                 println!("Using pre-built binary: {:?}", binary_path);
                 let mut c = Command::new(&binary_path);
                 c.args(&[
-                    "--connection-file",
-                    &connection_file_path,
+                    "--handshake-socket",
+                    &handshake_path,
                     "--transport",
                     "named-pipe",
                     "--token",
@@ -57,8 +63,8 @@ mod windows_named_pipe_tests {
                     "--bin",
                     "kcserver",
                     "--",
-                    "--connection-file",
-                    &connection_file_path,
+                    "--handshake-socket",
+                    &handshake_path,
                     "--transport",
                     "named-pipe",
                     "--token",
@@ -73,54 +79,20 @@ mod windows_named_pipe_tests {
             cmd.env("RUST_LOG", "debug");
 
             println!("Starting server with command: {:?}", cmd);
-            println!("Connection file path: {}", connection_file_path);
+            println!("Handshake socket path: {}", handshake_path);
             let child = cmd
                 .spawn()
                 .expect("Failed to start kcserver with named pipe");
 
-            // Wait longer for the server to start and write the connection file
-            let mut retries = 0;
-            let connection_info: serde_json::Value = loop {
-                tokio::time::sleep(Duration::from_millis(500)).await;
+            // Await the connection details over the handshake socket.
+            let connection_info = handshake
+                .recv()
+                .await
+                .expect("Failed to receive handshake payload");
 
-                println!("Attempt {}: Checking connection file...", retries + 1);
-
-                match std::fs::read_to_string(&connection_file_path) {
-                    Ok(content) if !content.trim().is_empty() => {
-                        println!("Connection file content: {}", content);
-                        match serde_json::from_str(&content) {
-                            Ok(info) => break info,
-                            Err(_) if retries < 10 => {
-                                retries += 1;
-                                continue;
-                            }
-                            Err(e) => panic!("Failed to parse connection file: {}", e),
-                        }
-                    }
-                    Ok(content) => {
-                        println!(
-                            "Connection file exists but is empty. Content: '{}'",
-                            content
-                        );
-                        if retries < 10 {
-                            retries += 1;
-                            continue;
-                        } else {
-                            panic!("Connection file is empty after 5 seconds");
-                        }
-                    }
-                    Err(e) if retries < 10 => {
-                        println!("Connection file doesn't exist yet: {}", e);
-                        retries += 1;
-                        continue;
-                    }
-                    Err(e) => panic!("Connection file error after 5 seconds: {}", e),
-                }
-            };
-            let pipe_name = connection_info["named_pipe"]
-                .as_str()
-                .expect("Missing named_pipe in connection file")
-                .to_string();
+            let pipe_name = connection_info
+                .named_pipe
+                .expect("Missing named_pipe in handshake payload");
             let test_server = NamedPipeTestServer { child, pipe_name };
 
             test_server


### PR DESCRIPTION
### Background

When Positron launches `kcserver`, the server needs to report back where it's listening (transport + address) and hand over the bearer token that gates its HTTP API. Until now this was done via a **connection file**: kcserver wrote a temp JSON file and Positron polled the filesystem until it appeared.

This has two problems:

- **Latency/reliability (the bug):** on Windows with aggressive antivirus, the file kcserver writes can be invisible to Positron for a long time (a reported ~32s delay) while it is scanned. kcserver writes it in milliseconds; the OS just won't let the client see it. See [posit-dev/positron#13388](https://github.com/posit-dev/positron/issues/13388).
- **Secret at rest:** the connection file also delivers a high-value secret (the bearer token, which can spawn kernels and run arbitrary code as the launching user), protected only by temp-file permissions.

### Approach

Invert the flow. Instead of *kcserver writing a file the client polls*, **the client creates and listens on a one-shot handshake socket first**, then launches kcserver pointing at it. A socket that already exists is not a file-at-rest for AV to scan, and there's no "server wrote something the client can't see yet" race — kcserver connects to a socket that's already there and the handoff is immediate. The token travels over a same-user-locked channel and never touches disk.

Flow:

1. Positron creates and listens on a handshake socket (Unix domain socket on Unix, named pipe on Windows), secured to the current user.
2. Positron launches kcserver with `--handshake-socket <path>` plus the usual `--transport`.
3. kcserver binds its main transport as before.
4. kcserver connects to the handshake socket as a client, writes a single JSON document (transport + address + bearer token + `server_id` + pid + log path), flushes, and closes.
5. Positron reads to EOF, persists what it needs (token into OS-backed secret storage), and connects to the main transport.

The handshake happens **only at initial launch**; reconnects use persisted state and perform no new handshake, preserving the "supervisor outlives the client" behavior. The handshake transport is independent of the main transport, so `--handshake-socket` never influences transport selection.

### Changes

- **New `handshake_socket` module** (`crates/kcserver/src/handshake_socket.rs`): defines the `HandshakePayload` struct (snake_case, matching the client's `KallichoreServerState`) and a cross-platform connect/write/close routine (Unix domain socket / Windows named pipe, with bounded retry on `ERROR_PIPE_BUSY`). A handshake failure is fatal for the launch and exits non-zero.
- **`main.rs`:** removed `--connection-file` and both `write_server_connection_file*` writers; added `--handshake-socket`; simplified `determine_transport` (dropped connection-file transport inference); gated the "generated token" console log on `handshake_socket.is_none()` so manual/dev runs still print the address and token.
- **`server.rs`:** `server_id` is now generated once in `main()` and threaded through `create_with_listener` and the three `create_*_server` constructors, so the id reported in the handshake matches the one the status endpoint later returns (the client relies on this for stale-server detection).
- **`transport.rs`:** tightened the Unix domain socket to `0600` (defense-in-depth for the temp-dir case).
- **Tests:** `wait_for_connection_file` replaced with a handshake helper that hosts a listening endpoint and reads/parses the payload; `connection_file_tests.rs` → `handshake_tests.rs`, rewritten to launch with `--handshake-socket` and assert transport/address/token/`server_id`; `named_pipe_test.rs` migrated to the handshake helper.
- **Docs:** `CLAUDE.md` / `README.md` updated to describe `--handshake-socket` and drop `--connection-file`.

### Wire contract

kcserver writes exactly one UTF-8 JSON document then closes; the client reads to EOF. Only the address field relevant to the transport is present:

```jsonc
{
  "transport":    "tcp" | "socket" | "named-pipe",
  "port":         49213,                         // TCP only
  "base_path":    "http://127.0.0.1:49213",      // TCP only
  "socket_path":  "/run/user/1000/kc-1234.sock", // Unix socket only
  "named_pipe":   "\\\\.\\pipe\\kallichore-1234", // Windows named pipe only
  "server_path":  "/path/to/kcserver",
  "server_pid":   1234,
  "bearer_token": "…",                           // null when --token none
  "log_path":     "/path/to/log",                // omitted if no --log-file
  "server_id":    "uuid-v4"
}
```

### Companion PR

Positron client side: posit-dev/positron#14773

